### PR TITLE
Dst less caching

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -457,6 +457,10 @@ watch_date_time_t movement_get_utc_date_time(void) {
     return watch_rtc_get_date_time();
 }
 
+bool movement_update_dst_offset_cache(void) {
+    return _movement_update_dst_offset_cache();
+}
+
 watch_date_time_t movement_get_date_time_in_zone(uint8_t zone_index) {
     int32_t offset = movement_get_current_timezone_offset_for_zone(zone_index);
     return watch_utility_date_time_convert_zone(watch_rtc_get_date_time(), 0, offset);

--- a/movement.h
+++ b/movement.h
@@ -340,6 +340,7 @@ void movement_set_timezone_index(uint8_t value);
 watch_date_time_t movement_get_utc_date_time(void);
 watch_date_time_t movement_get_local_date_time(void);
 watch_date_time_t movement_get_date_time_in_zone(uint8_t zone_index);
+bool movement_update_dst_offset_cache(void);
 
 void movement_set_local_date_time(watch_date_time_t date_time);
 

--- a/movement/watch_faces/clock/world_clock2_face.c
+++ b/movement/watch_faces/clock/world_clock2_face.c
@@ -152,6 +152,7 @@ void world_clock2_face_activate(void *context)
             movement_request_tick_frequency(4);
             break;
     }
+    movement_update_dst_offset_cache();
     refresh_face = true;
 }
 

--- a/movement/watch_faces/settings/finetune_face.c
+++ b/movement/watch_faces/settings/finetune_face.c
@@ -239,4 +239,5 @@ void finetune_face_resign(void *context) {
     if (total_adjustment != 0) {
         finetune_update_correction_time();
     }
+    movement_update_dst_offset_cache();
 }

--- a/movement/watch_faces/settings/set_time_hackwatch_face.c
+++ b/movement/watch_faces/settings/set_time_hackwatch_face.c
@@ -63,7 +63,7 @@ bool set_time_hackwatch_face_loop(movement_event_t event, void *context) {
             current_page = (current_page + set_time_hackwatch_face_NUM_SETTINGS - 1) % set_time_hackwatch_face_NUM_SETTINGS;
             if (current_page == 2)
                 seconds_reset_sequence = 0;
-
+            if (current_page == 6) movement_update_dst_offset_cache();
             *((uint8_t *)context) = current_page;
             break;
         case EVENT_LIGHT_BUTTON_UP:
@@ -265,4 +265,5 @@ void set_time_hackwatch_face_resign(void *context) {
     (void) context;
     watch_set_led_off();
     movement_store_settings();
+    movement_update_dst_offset_cache();
 }

--- a/watch-faces/clock/world_clock_face.c
+++ b/watch-faces/clock/world_clock_face.c
@@ -49,6 +49,7 @@ void world_clock_face_activate(void *context) {
     world_clock_state_t *state = (world_clock_state_t *)context;
 
     state->current_screen = 0;
+    movement_update_dst_offset_cache();
     _update_timezone_offset(state);
 
     if (watch_sleep_animation_is_running()) watch_stop_sleep_animation();

--- a/watch-faces/complication/sunrise_sunset_face.c
+++ b/watch-faces/complication/sunrise_sunset_face.c
@@ -49,21 +49,28 @@ static void _sunrise_sunset_face_update(sunrise_sunset_state_t *state) {
     double rise, set, minutes, seconds;
     bool show_next_match = false;
     movement_location_t movement_location;
-    if (state->longLatToUse == 0 || _location_count <= 1)
+    int32_t tz;
+    if (state->longLatToUse == 0 || _location_count <= 1) {
         movement_location = (movement_location_t) watch_get_backup_data(1);
+        tz = movement_get_current_timezone_offset();
+    }
     else{
         movement_location.bit.latitude = longLatPresets[state->longLatToUse].latitude;
         movement_location.bit.longitude = longLatPresets[state->longLatToUse].longitude;
+        tz = movement_get_current_timezone_offset_for_zone(longLatPresets[state->longLatToUse].timezone);
     }
 
     if (movement_location.reg == 0) {
+        watch_clear_colon();
+        watch_clear_indicator(WATCH_INDICATOR_PM);
+        watch_clear_indicator(WATCH_INDICATOR_24H);
         watch_display_text_with_fallback(WATCH_POSITION_TOP, "Sunri", "rI");
         watch_display_text_with_fallback(WATCH_POSITION_BOTTOM, "No LOC", "No Loc");
         return;
     }
 
-    watch_date_time_t date_time = movement_get_local_date_time(); // the current local date / time
-    watch_date_time_t utc_now = watch_utility_date_time_convert_zone(date_time, movement_get_current_timezone_offset(), 0); // the current date / time in UTC
+    watch_date_time_t utc_now = movement_get_utc_date_time();
+    watch_date_time_t date_time = watch_utility_date_time_convert_zone(utc_now, 0, tz);
     watch_date_time_t scratch_time; // scratchpad, contains different values at different times
     scratch_time.reg = utc_now.reg;
 
@@ -78,7 +85,7 @@ static void _sunrise_sunset_face_update(sunrise_sunset_state_t *state) {
     // sunriset returns the rise/set times as signed decimal hours in UTC.
     // this can mean hours below 0 or above 31, which won't fit into a watch_date_time_t struct.
     // to deal with this, we set aside the offset in hours, and add it back before converting it to a watch_date_time_t.
-    double hours_from_utc = ((double)movement_get_current_timezone_offset()) / 3600.0;
+    double hours_from_utc = ((double)tz) / 3600.0;
 
     // we loop twice because if it's after sunset today, we need to recalculate to display values for tomorrow.
     for(int i = 0; i < 2; i++) {
@@ -323,6 +330,7 @@ void sunrise_sunset_face_activate(void *context) {
     movement_location_t movement_location = (movement_location_t) watch_get_backup_data(1);
     state->working_latitude = _sunrise_sunset_face_struct_from_latlon(movement_location.bit.latitude);
     state->working_longitude = _sunrise_sunset_face_struct_from_latlon(movement_location.bit.longitude);
+    movement_update_dst_offset_cache();
 }
 
 bool sunrise_sunset_face_loop(movement_event_t event, void *context) {
@@ -335,8 +343,6 @@ bool sunrise_sunset_face_loop(movement_event_t event, void *context) {
         case EVENT_LOW_ENERGY_UPDATE:
         case EVENT_TICK:
             if (state->page == 0) {
-                // if entering low energy mode, start tick animation
-                if (event.event_type == EVENT_LOW_ENERGY_UPDATE && !watch_sleep_animation_is_running()) watch_start_sleep_animation(1000);
                 // check if we need to update the display
                 watch_date_time_t date_time = movement_get_local_date_time();
                 if (date_time.reg >= state->rise_set_expires.reg) {

--- a/watch-faces/complication/sunrise_sunset_face.c
+++ b/watch-faces/complication/sunrise_sunset_face.c
@@ -343,6 +343,8 @@ bool sunrise_sunset_face_loop(movement_event_t event, void *context) {
         case EVENT_LOW_ENERGY_UPDATE:
         case EVENT_TICK:
             if (state->page == 0) {
+                // if entering low energy mode, start tick animation
+                if (event.event_type == EVENT_LOW_ENERGY_UPDATE && !watch_sleep_animation_is_running()) watch_start_sleep_animation(1000);
                 // check if we need to update the display
                 watch_date_time_t date_time = movement_get_local_date_time();
                 if (date_time.reg >= state->rise_set_expires.reg) {

--- a/watch-faces/settings/set_time_face.c
+++ b/watch-faces/settings/set_time_face.c
@@ -32,6 +32,16 @@
 #define SET_TIME_FACE_NUM_SETTINGS (7)
 const char set_time_face_titles[SET_TIME_FACE_NUM_SETTINGS][3] = {"HR", "M1", "SE", "YR", "MO", "DA", "  "};
 
+typedef enum {
+    SET_TIME_HOUR = 0,
+    SET_TIME_MIN,
+    SET_TIME_SEC,
+    SET_TIME_YEAR,
+    SET_TIME_MONTH,
+    SET_TIME_DAY,
+    SET_TIME_TZ
+} set_time_pages;
+
 static bool _quick_ticks_running;
 static int32_t current_offset;
 
@@ -39,26 +49,25 @@ static void _handle_alarm_button(watch_date_time_t date_time, uint8_t current_pa
     // handles short or long pressing of the alarm button
 
     switch (current_page) {
-        case 0: // hour
+        case SET_TIME_HOUR:
             date_time.unit.hour = (date_time.unit.hour + 1) % 24;
             break;
-        case 1: // minute
+        case SET_TIME_MIN:
             date_time.unit.minute = (date_time.unit.minute + 1) % 60;
             break;
-        case 2: // second
+        case SET_TIME_SEC:
             date_time.unit.second = 0;
             break;
-        case 3: // year
+        case SET_TIME_YEAR:
             date_time.unit.year = ((date_time.unit.year % 60) + 1);
             break;
-        case 4: // month
+        case SET_TIME_MONTH:
             date_time.unit.month = (date_time.unit.month % 12) + 1;
             break;
-        case 5: { // day
+        case SET_TIME_DAY:
             date_time.unit.day = date_time.unit.day + 1;
             break;
-        }
-        case 6: // time zone
+        case SET_TIME_TZ:
             movement_set_timezone_index(movement_get_timezone_index() + 1);
             if (movement_get_timezone_index() >= NUM_ZONE_NAMES) movement_set_timezone_index(0);
             current_offset = movement_get_current_timezone_offset_for_zone(movement_get_timezone_index());
@@ -100,7 +109,7 @@ bool set_time_face_loop(movement_event_t event, void *context) {
             }
             break;
         case EVENT_ALARM_LONG_PRESS:
-            if (current_page != 2) {
+            if (current_page != SET_TIME_SEC) {
                 _quick_ticks_running = true;
                 movement_request_tick_frequency(8);
             }
@@ -114,6 +123,8 @@ bool set_time_face_loop(movement_event_t event, void *context) {
             return false;
         case EVENT_LIGHT_BUTTON_DOWN:
             current_page = (current_page + 1) % SET_TIME_FACE_NUM_SETTINGS;
+            if (current_page == SET_TIME_TZ && movement_update_dst_offset_cache())
+                current_offset = movement_get_current_timezone_offset();
             *((uint8_t *)context) = current_page;
             break;
         case EVENT_ALARM_BUTTON_UP:
@@ -131,7 +142,7 @@ bool set_time_face_loop(movement_event_t event, void *context) {
     char buf[11];
     watch_display_text(WATCH_POSITION_TOP_LEFT, (char *) set_time_face_titles[current_page]);
     watch_display_text(WATCH_POSITION_TOP_RIGHT, "  ");
-    if (current_page < 3) {
+    if (current_page < SET_TIME_YEAR) {
         watch_set_colon();
         if (movement_clock_mode_24h()) {
             watch_set_indicator(WATCH_INDICATOR_24H);
@@ -141,7 +152,7 @@ bool set_time_face_loop(movement_event_t event, void *context) {
             if (date_time.unit.hour < 12) watch_clear_indicator(WATCH_INDICATOR_PM);
             else watch_set_indicator(WATCH_INDICATOR_PM);
         }
-    } else if (current_page < 6) {
+    } else if (current_page < SET_TIME_TZ) {
         watch_clear_colon();
         watch_clear_indicator(WATCH_INDICATOR_24H);
         watch_clear_indicator(WATCH_INDICATOR_PM);
@@ -167,16 +178,16 @@ bool set_time_face_loop(movement_event_t event, void *context) {
     // blink up the parameter we're setting
     if (event.subsecond % 2 && !_quick_ticks_running) {
         switch (current_page) {
-            case 0:
-            case 3:
+            case SET_TIME_HOUR:
+            case SET_TIME_YEAR:
                 watch_display_text(WATCH_POSITION_HOURS, "  ");
                 break;
-            case 1:
-            case 4:
+            case SET_TIME_MIN:
+            case SET_TIME_MONTH:
                 watch_display_text(WATCH_POSITION_MINUTES, "  ");
                 break;
-            case 2:
-            case 5:
+            case SET_TIME_SEC:
+            case SET_TIME_DAY:
                 watch_display_text(WATCH_POSITION_SECONDS, "  ");
                 break;
         }
@@ -189,4 +200,5 @@ void set_time_face_resign(void *context) {
     (void) context;
     watch_set_led_off();
     movement_store_settings();
+    movement_update_dst_offset_cache();
 }


### PR DESCRIPTION
Now, we only do DST caching when it's the roll-over minute or if a face that changes the local time or views non-local time is called.