### PR TITLE
Changed submodules to reference HTTPS access rather than SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/littlefs-project/littlefs.git
 [submodule "gossamer"]
 	path = gossamer
-	url = git@github.com:joeycastillo/gossamer.git
+	url = https://github.com/joeycastillo/gossamer.git
 [submodule "utz"]
 	path = utz
-	url = git@github.com:joeycastillo/utz.git
+	url = https://github.com/joeycastillo/utz.git


### PR DESCRIPTION
It seems that the submodules reference the SSH path rather than the HTTPS path to the utz and gossamer repos.
This commit changes them to the HTTPS paths, making it easier for others to pull without needing SSH keys.