### PR TITLE
Made the simulator properly set itself with the UTC time on startup

### DIFF
--- a/watch-library/simulator/watch/watch_rtc.c
+++ b/watch-library/simulator/watch/watch_rtc.c
@@ -45,6 +45,12 @@ bool _watch_rtc_is_enabled(void) {
 }
 
 void _watch_rtc_init(void) {
+    // Shifts the timezone so our local time is converted to UTC and set
+    int32_t time_zone_offset = EM_ASM_INT({
+        return -new Date().getTimezoneOffset() * 60;
+    });
+    watch_date_time_t date_time = watch_rtc_get_date_time();
+    watch_rtc_set_date_time(watch_utility_date_time_convert_zone(date_time, time_zone_offset, 0));
 }
 
 void watch_rtc_set_date_time(watch_date_time_t date_time) {
@@ -62,9 +68,6 @@ void watch_rtc_set_date_time(watch_date_time_t date_time) {
 
 watch_date_time_t watch_rtc_get_date_time(void) {
     watch_date_time_t retval;
-    int32_t time_zone_offset = EM_ASM_INT({
-        return -new Date().getTimezoneOffset() * 60;
-    });
     retval.reg = EM_ASM_INT({
         const date = new Date(Date.now() + $0);
         return date.getSeconds() |
@@ -74,7 +77,6 @@ watch_date_time_t watch_rtc_get_date_time(void) {
             ((date.getMonth() + 1) << 22) |
             ((date.getFullYear() - 2020) << 26);
     }, time_offset);
-    retval = watch_utility_date_time_convert_zone(retval, time_zone_offset, 0);
     return retval;
 }
 


### PR DESCRIPTION
I found that the simulator may have an issue with the new UTC logic, where the watch initializes itself with the current time, rather than the UTC time.

This addition forces the simulator to have its on-board time be set as referenced to UTC>
There may be a better place to add this functionality, but it works very well for me.