### PR TITLE
Have move to face 0 as default timeout

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -285,6 +285,10 @@ bool movement_default_loop_handler(movement_event_t event) {
                 movement_move_to_face(0);
             }
             break;
+        case EVENT_TIMEOUT:
+            movement_move_to_face(0);
+            break;
+
         default:
             break;
     }


### PR DESCRIPTION
This is coming from developing a couple of faces now.

I was surprised to learn this was not the default behavior, and I had to specifically make sure timing out made the face go back to 0. 

Since it's so easy to override, and most faces actually do it already, it would make sense to me?