### PR TITLE
Add more comments about the flag BOARD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 GOSSAMER_PATH=gossamer
 
 # Which board are we building for?
+# Options are:
+# - sensorwatch_pro
+# - sensorwatch_green
+# - sensorwatch_red (also known as Sensor Watch Lite)
 BOARD=sensorwatch_pro
 
 # Which screen are we building for?


### PR DESCRIPTION
I was flashing my first custom built firmware for the Lite, but the screen was. Eheh, very buggy. 

I was a little stumped for a while, and then I went ahead to see if I could download some stock firmware instead. I saw then that this firmware was available as separate links for red, green and blue boards. Then it dawned on me.

Without really finding any docs on it, I managed to find out what the correct option were, and it compiled and installed just fine this time. I think we should document it _at least_ in the Makefile.

So here is a PR doing just that.