### PR TITLE
Fix simulator LCD handling

### DIFF
--- a/watch-library/simulator/watch/watch_slcd.c
+++ b/watch-library/simulator/watch/watch_slcd.c
@@ -37,6 +37,10 @@ static long blink_interval_id = - 1;
 static bool tick_state;
 static long tick_interval_id = -1;
 
+watch_lcd_type_t watch_get_lcd_type(void) {
+    return WATCH_LCD_TYPE_CLASSIC;
+}
+
 void watch_enable_display(void) {
     watch_clear_display();
 }


### PR DESCRIPTION
A function was now missing in the simulator firmware 

Specifically 

> wasm-ld: error: ./build-sim/watch_utility.o: undefined symbol: watch_get_lcd_type

Would be nice to have a custom LCD simulator of course, but quite out of scope for this PR 🤓