### PR TITLE
Update Makefile to conditionally require BOARD and DISPLAY only for non-clean targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ endif
 # Add your include directories here.
 INCLUDES += \
   -I./ \
+  -I. \
   -I./tinyusb/src \
   -I./littlefs \
   -I./utz \


### PR DESCRIPTION
This lets you run `make clean` without having to specify BOARD or DISPLAY. We just skip the checks for those variables if we're only cleaning. Goes along with [gossamer PR #1](https://github.com/joeycastillo/gossamer/pull/1) that does the same thing in the submodule. Together, these make cleaning up builds a bit easier.