### PR TITLE
Fix longitude corruption bug in sunrise/sunset face

### DIFF
--- a/watch-faces/complication/sunrise_sunset_face.c
+++ b/watch-faces/complication/sunrise_sunset_face.c
@@ -478,7 +478,7 @@ void sunrise_sunset_face_activate(void *context) {
 #endif
 
     sunrise_sunset_state_t *state = (sunrise_sunset_state_t *)context;
-    movement_location_t movement_location = load_location_from_filesystem();    
+    movement_location_t movement_location = load_location_from_filesystem();
     state->working_latitude = _sunrise_sunset_face_struct_from_latlon(movement_location.bit.latitude);
     state->working_longitude = _sunrise_sunset_face_struct_from_latlon(movement_location.bit.longitude);
 }

--- a/watch-faces/complication/sunrise_sunset_face.c
+++ b/watch-faces/complication/sunrise_sunset_face.c
@@ -200,7 +200,6 @@ static int16_t _sunrise_sunset_face_latlon_from_struct(sunrise_sunset_lat_lon_se
     return retval;
 }
 
-
 static sunrise_sunset_lat_lon_settings_t _sunrise_sunset_face_struct_from_latlon(int16_t val) {
     sunrise_sunset_lat_lon_settings_t retval;
 

--- a/watch-faces/complication/sunrise_sunset_face.c
+++ b/watch-faces/complication/sunrise_sunset_face.c
@@ -127,6 +127,15 @@ static void _sunrise_sunset_face_update(sunrise_sunset_state_t *state) {
         if (seconds < 30) scratch_time.unit.minute = floor(minutes);
         else scratch_time.unit.minute = ceil(minutes);
 
+        // Handle hour overflow from timezone conversion
+        while (scratch_time.unit.hour >= 24) {
+            scratch_time.unit.hour -= 24;
+            // Increment day (this will be handled by the date arithmetic)
+            uint32_t timestamp = watch_utility_date_time_to_unix_time(scratch_time, 0);
+            timestamp += 86400;
+            scratch_time = watch_utility_date_time_from_unix_time(timestamp, 0);
+        }
+
         if (scratch_time.unit.minute == 60) {
             scratch_time.unit.minute = 0;
             scratch_time.unit.hour = (scratch_time.unit.hour + 1) % 24;
@@ -156,6 +165,15 @@ static void _sunrise_sunset_face_update(sunrise_sunset_state_t *state) {
         scratch_time.unit.hour = floor(set);
         if (seconds < 30) scratch_time.unit.minute = floor(minutes);
         else scratch_time.unit.minute = ceil(minutes);
+
+        // Handle hour overflow from timezone conversion
+        while (scratch_time.unit.hour >= 24) {
+            scratch_time.unit.hour -= 24;
+            // Increment day (this will be handled by the date arithmetic)
+            uint32_t timestamp = watch_utility_date_time_to_unix_time(scratch_time, 0);
+            timestamp += 86400;
+            scratch_time = watch_utility_date_time_from_unix_time(timestamp, 0);
+        }
 
         if (scratch_time.unit.minute == 60) {
             scratch_time.unit.minute = 0;

--- a/watch-faces/complication/sunrise_sunset_face.c
+++ b/watch-faces/complication/sunrise_sunset_face.c
@@ -239,6 +239,7 @@ static void _sunrise_sunset_face_update_settings_display(movement_event_t event,
         case 0:
             return;
         case 1:
+            // Latitude
             watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "LAT", "LA");
             if (watch_get_lcd_type() == WATCH_LCD_TYPE_CUSTOM) {
                 watch_set_decimal_if_available();
@@ -262,12 +263,13 @@ static void _sunrise_sunset_face_update_settings_display(movement_event_t event,
             }
             break;
         case 2:
+            // Longitude
             watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "LON", "LO");
             if (watch_get_lcd_type() == WATCH_LCD_TYPE_CUSTOM) {
                 watch_set_decimal_if_available();
                 // Handle leading 1 for longitudes >99
-                if (state->working_longitude.tens > 9) watch_set_pixel(0, 22);
-                watch_display_character('0' + state->working_longitude.tens % 10, 4);
+                if (state->working_longitude.hundreds == 1) watch_set_pixel(0, 22);
+                watch_display_character('0' + state->working_longitude.tens, 4);
                 watch_display_character('0' + state->working_longitude.ones, 5);
                 watch_display_character('0' + state->working_longitude.tenths, 6);
                 watch_display_character('0' + state->working_longitude.hundredths, 7);
@@ -326,7 +328,14 @@ static void _sunrise_sunset_face_advance_digit(sunrise_sunset_state_t *state) {
             case 2: // longitude
                 switch (state->active_digit) {
                     case 0:
-                        state->working_longitude.tens = (state->working_longitude.tens + 1) % 18;
+                        // Increase tens and handle carry-over to hundreds
+                        state->working_longitude.tens++;
+                        if (state->working_longitude.tens >= 10) {
+                            state->working_longitude.tens = 0;
+                            state->working_longitude.hundreds++;
+                        }
+
+                        // Reset if we've gone over ±180
                         if (abs(_sunrise_sunset_face_latlon_from_struct(state->working_longitude)) > 18000) {
                             state->working_longitude.hundreds = 0;
                             state->working_longitude.tens = 0;

--- a/watch-faces/complication/sunrise_sunset_face.c
+++ b/watch-faces/complication/sunrise_sunset_face.c
@@ -200,6 +200,7 @@ static int16_t _sunrise_sunset_face_latlon_from_struct(sunrise_sunset_lat_lon_se
     return retval;
 }
 
+
 static sunrise_sunset_lat_lon_settings_t _sunrise_sunset_face_struct_from_latlon(int16_t val) {
     sunrise_sunset_lat_lon_settings_t retval;
 
@@ -328,6 +329,8 @@ static void _sunrise_sunset_face_advance_digit(sunrise_sunset_state_t *state) {
                     case 0:
                         state->working_longitude.tens = (state->working_longitude.tens + 1) % 18;
                         if (abs(_sunrise_sunset_face_latlon_from_struct(state->working_longitude)) > 18000) {
+                            state->working_longitude.hundreds = 0;
+                            state->working_longitude.tens = 0;
                             state->working_longitude.ones = 0;
                             state->working_longitude.tenths = 0;
                             state->working_longitude.hundredths = 0;
@@ -422,6 +425,32 @@ static void _sunrise_sunset_face_advance_digit(sunrise_sunset_state_t *state) {
     }
 }
 
+static bool _sunrise_sunset_face_is_longitude_corrupted(sunrise_sunset_lat_lon_settings_t lon_struct) {
+    int16_t lon_value = _sunrise_sunset_face_latlon_from_struct(lon_struct);
+    return (lon_struct.tens > 9) || (abs(lon_value) > 18000);
+}
+
+static sunrise_sunset_lat_lon_settings_t _sunrise_sunset_face_recover_longitude(sunrise_sunset_lat_lon_settings_t corrupted) {
+    sunrise_sunset_lat_lon_settings_t recovered = {0};
+    
+    if (corrupted.tens > 9) {
+        recovered.hundreds = corrupted.tens / 10;
+        recovered.tens = corrupted.tens % 10;
+        recovered.ones = corrupted.ones;
+        recovered.tenths = corrupted.tenths;
+        recovered.hundredths = corrupted.hundredths;
+        recovered.sign = corrupted.sign;
+        
+        int16_t recovered_value = _sunrise_sunset_face_latlon_from_struct(recovered);
+        if (abs(recovered_value) <= 18000) {
+            return recovered;
+        }
+    }
+    
+    memset(&recovered, 0, sizeof(recovered));
+    return recovered;
+}
+
 void sunrise_sunset_face_setup(uint8_t watch_face_index, void ** context_ptr) {
     (void) watch_face_index;
     if (*context_ptr == NULL) {
@@ -453,6 +482,16 @@ void sunrise_sunset_face_activate(void *context) {
     movement_location_t movement_location = load_location_from_filesystem();
     state->working_latitude = _sunrise_sunset_face_struct_from_latlon(movement_location.bit.latitude);
     state->working_longitude = _sunrise_sunset_face_struct_from_latlon(movement_location.bit.longitude);
+
+    // Detect and recover from corrupted longitude data
+    if (_sunrise_sunset_face_is_longitude_corrupted(state->working_longitude)) {
+        sunrise_sunset_lat_lon_settings_t recovered = _sunrise_sunset_face_recover_longitude(state->working_longitude);
+        state->working_longitude = recovered;
+        
+        // Save the corrected location immediately
+        state->location_changed = true;
+        _sunrise_sunset_face_update_location_register(state);
+    }
 }
 
 bool sunrise_sunset_face_loop(movement_event_t event, void *context) {


### PR DESCRIPTION
The sunrise/sunset face had a critical bug in longitude handling for custom LCD displays:

- Longitude values >99° would get corrupted during save/load cycles (e.g., 128.00° became 28.00°)
- When the tens digit reached 8+, other digits would reset to zero and become stuck
- This caused invalid sunrise/sunset time calculations (e.g., 29:31)
- The only workaround was manually deleting the location.u32 file as location is persisted to the file system

Root cause is that the custom LCD mode uses a % 18 range for the tens digit to represent longitudes 0-179°, but this causes data corruption because:

- The hundreds digit was packed into the tens field (e.g., 128° → tens = 12)
- The conversion functions expected normal digit separation
- During save/load cycles, the packed data would be interpreted incorrectly
- Boundary handling was incomplete