### PR TITLE
Set time on make

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -664,19 +664,16 @@ void app_init(void) {
         movement_store_settings();
     }
 
-    // populate the DST offset cache
-    _movement_update_dst_offset_cache();
-
     watch_date_time_t date_time = watch_rtc_get_date_time();
     if (date_time.reg == 0) {
-        // at first boot, set year to 2025
-        date_time.unit.year = 2025 - WATCH_RTC_REFERENCE_YEAR;
-        date_time.unit.month = 1;
-        date_time.unit.day = 1;
+        date_time = watch_get_init_date_time();
         // but convert from local time to UTC
         date_time = watch_utility_date_time_convert_zone(date_time, movement_get_current_timezone_offset(), 0);
         watch_rtc_set_date_time(date_time);
     }
+
+    // populate the DST offset cache
+    _movement_update_dst_offset_cache();
 
     if (movement_state.accelerometer_motion_threshold == 0) movement_state.accelerometer_motion_threshold = 32;
 

--- a/movement.c
+++ b/movement.c
@@ -702,7 +702,14 @@ void app_setup(void) {
             is_first_launch = false;
         }
 
-#if __EMSCRIPTEN__
+#ifdef MAKEFILE_TIMEZONE
+    for (int i = 0; i < NUM_ZONE_NAMES; i++) {
+        if (movement_get_current_timezone_offset_for_zone(i) == MAKEFILE_TIMEZONE * 60) {
+            movement_state.settings.bit.time_zone = i;
+            break;
+        }
+    }
+#elif __EMSCRIPTEN__
         int32_t time_zone_offset = EM_ASM_INT({
             return -new Date().getTimezoneOffset();
         });

--- a/movement.c
+++ b/movement.c
@@ -203,6 +203,15 @@ static void _movement_handle_scheduled_tasks(void) {
     }
 }
 
+static void movement_set_location_to_filesystem(movement_location_t new_location) {
+    movement_location_t maybe_location = {0};
+
+    filesystem_read_file("location.u32", (char *) &maybe_location.reg, sizeof(movement_location_t));
+    if (new_location.reg != maybe_location.reg) {
+        filesystem_write_file("location.u32", (char *) &new_location.reg, sizeof(movement_location_t));
+    }
+}
+
 void movement_request_tick_frequency(uint8_t freq) {
     // Movement uses the 128 Hz tick internally
     if (freq == 128) return;
@@ -660,6 +669,13 @@ void app_init(void) {
         movement_state.settings.bit.le_interval = MOVEMENT_DEFAULT_LOW_ENERGY_INTERVAL;
 #endif
         movement_state.settings.bit.led_duration = MOVEMENT_DEFAULT_LED_DURATION;
+
+#if defined(MOVEMENT_DEFAULT_LATITUDE) && defined(MOVEMENT_DEFAULT_LONGITUDE)
+    movement_set_location_to_filesystem((movement_location_t){
+        .bit.latitude = MOVEMENT_DEFAULT_LATITUDE,
+        .bit.longitude = MOVEMENT_DEFAULT_LONGITUDE
+    });
+#endif
 
         movement_store_settings();
     }

--- a/movement.c
+++ b/movement.c
@@ -718,14 +718,7 @@ void app_setup(void) {
             is_first_launch = false;
         }
 
-#ifdef MAKEFILE_TIMEZONE
-    for (int i = 0; i < NUM_ZONE_NAMES; i++) {
-        if (movement_get_current_timezone_offset_for_zone(i) == MAKEFILE_TIMEZONE * 60) {
-            movement_state.settings.bit.time_zone = i;
-            break;
-        }
-    }
-#elif __EMSCRIPTEN__
+#if __EMSCRIPTEN__
         int32_t time_zone_offset = EM_ASM_INT({
             return -new Date().getTimezoneOffset();
         });

--- a/movement.c
+++ b/movement.c
@@ -203,15 +203,6 @@ static void _movement_handle_scheduled_tasks(void) {
     }
 }
 
-static void movement_set_location_to_filesystem(movement_location_t new_location) {
-    movement_location_t maybe_location = {0};
-
-    filesystem_read_file("location.u32", (char *) &maybe_location.reg, sizeof(movement_location_t));
-    if (new_location.reg != maybe_location.reg) {
-        filesystem_write_file("location.u32", (char *) &new_location.reg, sizeof(movement_location_t));
-    }
-}
-
 void movement_request_tick_frequency(uint8_t freq) {
     // Movement uses the 128 Hz tick internally
     if (freq == 128) return;
@@ -669,13 +660,6 @@ void app_init(void) {
         movement_state.settings.bit.le_interval = MOVEMENT_DEFAULT_LOW_ENERGY_INTERVAL;
 #endif
         movement_state.settings.bit.led_duration = MOVEMENT_DEFAULT_LED_DURATION;
-
-#if defined(MOVEMENT_DEFAULT_LATITUDE) && defined(MOVEMENT_DEFAULT_LONGITUDE)
-    movement_set_location_to_filesystem((movement_location_t){
-        .bit.latitude = MOVEMENT_DEFAULT_LATITUDE,
-        .bit.longitude = MOVEMENT_DEFAULT_LONGITUDE
-    });
-#endif
 
         movement_store_settings();
     }

--- a/movement_config.h
+++ b/movement_config.h
@@ -100,10 +100,4 @@ const watch_face_t watch_faces[] = {
  */
 #define MOVEMENT_DEFAULT_LED_DURATION 1
 
-/* The latitude and longitude used for the wearers location
- * Set signed values in 1/100ths of a degree
- */
-#define MOVEMENT_DEFAULT_LATITUDE 0
-#define MOVEMENT_DEFAULT_LONGITUDE 0
-
 #endif // MOVEMENT_CONFIG_H_

--- a/movement_config.h
+++ b/movement_config.h
@@ -100,4 +100,10 @@ const watch_face_t watch_faces[] = {
  */
 #define MOVEMENT_DEFAULT_LED_DURATION 1
 
+/* The latitude and longitude used for the wearers location
+ * Set signed values in 1/100ths of a degree
+ */
+#define MOVEMENT_DEFAULT_LATITUDE 0
+#define MOVEMENT_DEFAULT_LONGITUDE 0
+
 #endif // MOVEMENT_CONFIG_H_

--- a/watch-faces/settings/settings_face.c
+++ b/watch-faces/settings/settings_face.c
@@ -215,6 +215,15 @@ static void blue_led_setting_advance(void) {
     movement_set_backlight_color(color);
 }
 
+static void  git_hash_setting_display(uint8_t subsecond) {
+    watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "GH ", "GH");
+    watch_display_text(WATCH_POSITION_BOTTOM, MAKEFILE_GIT_HASH);  // MAKEFILE_GIT_HASH must be at most 6 characters, which Makefile should truncate
+}
+
+static void git_hash_setting_advance(void) {
+    return;
+}
+
 void settings_face_setup(uint8_t watch_face_index, void ** context_ptr) {
     (void) watch_face_index;
     if (*context_ptr == NULL) {
@@ -223,6 +232,9 @@ void settings_face_setup(uint8_t watch_face_index, void ** context_ptr) {
         int8_t current_setting = 0;
 
         state->num_settings = 5; // baseline, without LED settings
+#ifdef MAKEFILE_GIT_HASH
+        state->num_settings++;
+#endif
 #ifdef WATCH_RED_TCC_CHANNEL
         state->num_settings++;
 #endif
@@ -246,6 +258,11 @@ void settings_face_setup(uint8_t watch_face_index, void ** context_ptr) {
 #ifndef MOVEMENT_LOW_ENERGY_MODE_FORBIDDEN
         state->settings_screens[current_setting].display = low_energy_setting_display;
         state->settings_screens[current_setting].advance = low_energy_setting_advance;
+        current_setting++;
+#endif
+#ifdef MAKEFILE_GIT_HASH
+        state->settings_screens[current_setting].display = git_hash_setting_display;
+        state->settings_screens[current_setting].advance = git_hash_setting_advance;
         current_setting++;
 #endif
         state->settings_screens[current_setting].display = led_duration_setting_display;

--- a/watch-faces/settings/settings_face.c
+++ b/watch-faces/settings/settings_face.c
@@ -216,6 +216,7 @@ static void blue_led_setting_advance(void) {
 }
 
 static void  git_hash_setting_display(uint8_t subsecond) {
+    (void) subsecond;
     char buf[8];
     // BUILD_GIT_HASH will already be truncated to 6 characters in the makefile, but this is to be safe.
     sprintf(buf, "%.6s", BUILD_GIT_HASH);

--- a/watch-faces/settings/settings_face.c
+++ b/watch-faces/settings/settings_face.c
@@ -217,8 +217,8 @@ static void blue_led_setting_advance(void) {
 
 static void  git_hash_setting_display(uint8_t subsecond) {
     char buf[8];
-    // MAKEFILE_GIT_HASH will already be truncated to 6 characters in the makefile, but this is to be safe.
-    sprintf(buf, "%.6s", MAKEFILE_GIT_HASH);
+    // BUILD_GIT_HASH will already be truncated to 6 characters in the makefile, but this is to be safe.
+    sprintf(buf, "%.6s", BUILD_GIT_HASH);
     watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "GH ", "GH");
     watch_display_text(WATCH_POSITION_BOTTOM, buf);
 }
@@ -235,7 +235,7 @@ void settings_face_setup(uint8_t watch_face_index, void ** context_ptr) {
         int8_t current_setting = 0;
 
         state->num_settings = 5; // baseline, without LED settings
-#ifdef MAKEFILE_GIT_HASH
+#ifdef BUILD_GIT_HASH
         state->num_settings++;
 #endif
 #ifdef WATCH_RED_TCC_CHANNEL
@@ -263,7 +263,7 @@ void settings_face_setup(uint8_t watch_face_index, void ** context_ptr) {
         state->settings_screens[current_setting].advance = low_energy_setting_advance;
         current_setting++;
 #endif
-#ifdef MAKEFILE_GIT_HASH
+#ifdef BUILD_GIT_HASH
         state->settings_screens[current_setting].display = git_hash_setting_display;
         state->settings_screens[current_setting].advance = git_hash_setting_advance;
         current_setting++;

--- a/watch-faces/settings/settings_face.c
+++ b/watch-faces/settings/settings_face.c
@@ -216,8 +216,11 @@ static void blue_led_setting_advance(void) {
 }
 
 static void  git_hash_setting_display(uint8_t subsecond) {
+    char buf[8];
+    // MAKEFILE_GIT_HASH will already be truncated to 6 characters in the makefile, but this is to be safe.
+    sprintf(buf, "%.6s", MAKEFILE_GIT_HASH);
     watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "GH ", "GH");
-    watch_display_text(WATCH_POSITION_BOTTOM, MAKEFILE_GIT_HASH);  // MAKEFILE_GIT_HASH must be at most 6 characters, which Makefile should truncate
+    watch_display_text(WATCH_POSITION_BOTTOM, buf);
 }
 
 static void git_hash_setting_advance(void) {

--- a/watch-library/hardware/watch/watch_rtc.c
+++ b/watch-library/hardware/watch/watch_rtc.c
@@ -56,6 +56,32 @@ rtc_date_time_t watch_rtc_get_date_time(void) {
     return rtc_get_date_time();
 }
 
+rtc_date_time_t watch_get_init_date_time(void) {
+    rtc_date_time_t date_time;
+#ifdef MAKEFILE_CURR_YEAR
+    date_time.unit.year = MAKEFILE_CURR_YEAR;
+#else
+    date_time.unit.year = 5;
+#endif
+#ifdef MAKEFILE_CURR_MONTH
+    date_time.unit.month = MAKEFILE_CURR_MONTH;
+#else
+    date_time.unit.month = 1;
+#endif
+#ifdef MAKEFILE_CURR_DAY
+    date_time.unit.day = MAKEFILE_CURR_DAY;
+#else
+    date_time.unit.day = 1;
+#endif
+#ifdef MAKEFILE_CURR_HOUR
+    date_time.unit.hour = MAKEFILE_CURR_HOUR;
+#endif
+#ifdef MAKEFILE_CURR_MINUTE
+    date_time.unit.minute = MAKEFILE_CURR_MINUTE;
+#endif
+    return date_time;
+}
+
 void watch_rtc_register_tick_callback(watch_cb_t callback) {
     watch_rtc_register_periodic_callback(callback, 1);
 }

--- a/watch-library/hardware/watch/watch_rtc.c
+++ b/watch-library/hardware/watch/watch_rtc.c
@@ -58,26 +58,26 @@ rtc_date_time_t watch_rtc_get_date_time(void) {
 
 rtc_date_time_t watch_get_init_date_time(void) {
     rtc_date_time_t date_time;
-#ifdef MAKEFILE_CURR_YEAR
-    date_time.unit.year = MAKEFILE_CURR_YEAR;
+#ifdef BUILD_YEAR
+    date_time.unit.year = BUILD_YEAR;
 #else
     date_time.unit.year = 5;
 #endif
-#ifdef MAKEFILE_CURR_MONTH
-    date_time.unit.month = MAKEFILE_CURR_MONTH;
+#ifdef BUILD_MONTH
+    date_time.unit.month = BUILD_MONTH;
 #else
     date_time.unit.month = 1;
 #endif
-#ifdef MAKEFILE_CURR_DAY
-    date_time.unit.day = MAKEFILE_CURR_DAY;
+#ifdef BUILD_DAY
+    date_time.unit.day = BUILD_DAY;
 #else
     date_time.unit.day = 1;
 #endif
-#ifdef MAKEFILE_CURR_HOUR
-    date_time.unit.hour = MAKEFILE_CURR_HOUR;
+#ifdef BUILD_HOUR
+    date_time.unit.hour = BUILD_HOUR;
 #endif
-#ifdef MAKEFILE_CURR_MINUTE
-    date_time.unit.minute = MAKEFILE_CURR_MINUTE;
+#ifdef BUILD_MINUTE
+    date_time.unit.minute = BUILD_MINUTE;
 #endif
     return date_time;
 }

--- a/watch-library/shared/watch/watch_rtc.h
+++ b/watch-library/shared/watch/watch_rtc.h
@@ -68,6 +68,11 @@ void watch_rtc_set_date_time(rtc_date_time_t date_time);
   */
 rtc_date_time_t watch_rtc_get_date_time(void);
 
+/** @brief Returns the date and time that the watch defaults to when power cycled. Often comes from the Makefile flags.
+  * @return A rtc_date_time_t with the current date and time, with a year value from 0-63 representing 2020-2083.
+  */
+rtc_date_time_t watch_get_init_date_time(void);
+
 /** @brief Registers an alarm callback that will be called when the RTC time matches the target time, as masked
   *        by the provided mask.
   * @param callback The function you wish to have called when the alarm fires. If this value is NULL, the alarm

--- a/watch-library/simulator/watch/watch_rtc.c
+++ b/watch-library/simulator/watch/watch_rtc.c
@@ -45,9 +45,7 @@ bool _watch_rtc_is_enabled(void) {
 }
 
 void _watch_rtc_init(void) {
-#ifdef MAKEFILE_TIMEZONE
-    int32_t time_zone_offset = MAKEFILE_TIMEZONE * 60;
-#else
+#if EMSCRIPTEN
     // Shifts the timezone so our local time is converted to UTC and set
     int32_t time_zone_offset = EM_ASM_INT({
         return -new Date().getTimezoneOffset() * 60;

--- a/watch-library/simulator/watch/watch_rtc.c
+++ b/watch-library/simulator/watch/watch_rtc.c
@@ -51,7 +51,7 @@ void _watch_rtc_init(void) {
         return -new Date().getTimezoneOffset() * 60;
     });
 #endif
-#ifdef MAKEFILE_CURR_YEAR
+#ifdef BUILD_YEAR
     watch_date_time_t date_time = watch_get_init_date_time();
 #else
     watch_date_time_t date_time = watch_rtc_get_date_time();
@@ -88,26 +88,26 @@ watch_date_time_t watch_rtc_get_date_time(void) {
 
 rtc_date_time_t watch_get_init_date_time(void) {
     rtc_date_time_t date_time;
-#ifdef MAKEFILE_CURR_YEAR
-    date_time.unit.year = MAKEFILE_CURR_YEAR;
+#ifdef BUILD_YEAR
+    date_time.unit.year = BUILD_YEAR;
 #else
     date_time.unit.year = 5;
 #endif
-#ifdef MAKEFILE_CURR_MONTH
-    date_time.unit.month = MAKEFILE_CURR_MONTH;
+#ifdef BUILD_MONTH
+    date_time.unit.month = BUILD_MONTH;
 #else
     date_time.unit.month = 1;
 #endif
-#ifdef MAKEFILE_CURR_DAY
-    date_time.unit.day = MAKEFILE_CURR_DAY;
+#ifdef BUILD_DAY
+    date_time.unit.day = BUILD_DAY;
 #else
     date_time.unit.day = 1;
 #endif
-#ifdef MAKEFILE_CURR_HOUR
-    date_time.unit.hour = MAKEFILE_CURR_HOUR;
+#ifdef BUILD_HOUR
+    date_time.unit.hour = BUILD_HOUR;
 #endif
-#ifdef MAKEFILE_CURR_MINUTE
-    date_time.unit.minute = MAKEFILE_CURR_MINUTE;
+#ifdef BUILD_MINUTE
+    date_time.unit.minute = BUILD_MINUTE;
 #endif
     return date_time;
 }

--- a/watch-library/simulator/watch/watch_rtc.c
+++ b/watch-library/simulator/watch/watch_rtc.c
@@ -45,11 +45,19 @@ bool _watch_rtc_is_enabled(void) {
 }
 
 void _watch_rtc_init(void) {
+#ifdef MAKEFILE_TIMEZONE
+    int32_t time_zone_offset = MAKEFILE_TIMEZONE * 60;
+#else
     // Shifts the timezone so our local time is converted to UTC and set
     int32_t time_zone_offset = EM_ASM_INT({
         return -new Date().getTimezoneOffset() * 60;
     });
+#endif
+#ifdef MAKEFILE_CURR_YEAR
+    watch_date_time_t date_time = watch_get_init_date_time();
+#else
     watch_date_time_t date_time = watch_rtc_get_date_time();
+#endif
     watch_rtc_set_date_time(watch_utility_date_time_convert_zone(date_time, time_zone_offset, 0));
 }
 
@@ -78,6 +86,32 @@ watch_date_time_t watch_rtc_get_date_time(void) {
             ((date.getFullYear() - 2020) << 26);
     }, time_offset);
     return retval;
+}
+
+rtc_date_time_t watch_get_init_date_time(void) {
+    rtc_date_time_t date_time;
+#ifdef MAKEFILE_CURR_YEAR
+    date_time.unit.year = MAKEFILE_CURR_YEAR;
+#else
+    date_time.unit.year = 5;
+#endif
+#ifdef MAKEFILE_CURR_MONTH
+    date_time.unit.month = MAKEFILE_CURR_MONTH;
+#else
+    date_time.unit.month = 1;
+#endif
+#ifdef MAKEFILE_CURR_DAY
+    date_time.unit.day = MAKEFILE_CURR_DAY;
+#else
+    date_time.unit.day = 1;
+#endif
+#ifdef MAKEFILE_CURR_HOUR
+    date_time.unit.hour = MAKEFILE_CURR_HOUR;
+#endif
+#ifdef MAKEFILE_CURR_MINUTE
+    date_time.unit.minute = MAKEFILE_CURR_MINUTE;
+#endif
+    return date_time;
 }
 
 void watch_rtc_register_tick_callback(watch_cb_t callback) {

--- a/watch-library/simulator/watch/watch_rtc.c
+++ b/watch-library/simulator/watch/watch_rtc.c
@@ -87,7 +87,8 @@ watch_date_time_t watch_rtc_get_date_time(void) {
 }
 
 rtc_date_time_t watch_get_init_date_time(void) {
-    rtc_date_time_t date_time;
+    rtc_date_time_t date_time = {0};
+
 #ifdef BUILD_YEAR
     date_time.unit.year = BUILD_YEAR;
 #else
@@ -109,6 +110,7 @@ rtc_date_time_t watch_get_init_date_time(void) {
 #ifdef BUILD_MINUTE
     date_time.unit.minute = BUILD_MINUTE;
 #endif
+
     return date_time;
 }
 


### PR DESCRIPTION
The time that the program is compiled can now be saved onto the Sensorwatch.
This commit also includes a screen in the settings that shows the current Git hash.
Finally, it also includes being able to set the longitude and latitude in the code to avoid needing to set it manually between flashes.
This is done by setting DATE on the make.

`make BOARD=sensorwatch_pro DISPLAY=custom DATE=MIN`

Options
#  YEAR = Sets the year and timezone to the PC's
#  DAY = Sets the default time down to the day (year, month, day, timezone)
#  MIN = Sets the default time down to the minute (year, month, day, timezone, hour, minute)