### PR TITLE
Build in CI using a build matrix 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
           - "sensorwatch_pro"
         display:
           - "classic"
+          - "custom"
     env:
       BOARD: ${{ matrix.board }}
       DISPLAY: ${{ matrix.display }}


### PR DESCRIPTION
Here we are adding a matrix.

This makes sure second movement compile in all known configurations

It's also using a matrix for the simulator, but for some reason it did not compile with board set to custom. Which is exactly the kind of thing this is meant to uncover 🤓🎉

Edit: upon further research I am pretty sure the failure in simulator build is due to https://discord.com/channels/969627287429459988/1029086310192918538/1391800904893730917 and not the matrix, so adding it back