### PR TITLE
Ensure git directory is marked as safe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Ensure workspace directory is defined as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Compile movement firmware
         run: make
         working-directory: '.'
@@ -38,6 +40,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Ensure workspace directory is defined as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Compile movement
         run: emmake make
         working-directory: '.'


### PR DESCRIPTION
This is especially useful after #35 was merged and make in the pipeline is attempting to populate GIT_HASH

This error can now be observed in the latest build on main (at the time of writing https://github.com/joeycastillo/second-movement/actions/runs/16102782310/job/45434086620#step:4:8 for example)

Then observe how the builds in this PR does not have the same issue. End consequence is also that firmware built in CI currently does not have GIT_HASH populated which seems interesting enough to fix 🤓✌️