### PR TITLE
Fix command line in simulator

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -944,10 +944,14 @@ bool app_loop(void) {
         }
     }
 
+#if __EMSCRIPTEN__
+    shell_task();
+#else
     // if we are plugged into USB, handle the serial shell
     if (usb_is_enabled()) {
         shell_task();
     }
+#endif
 
     event.subsecond = 0;
 


### PR DESCRIPTION
In the original movement, the 'usb enabled' check was overridden to true for the simulator such that shell_task() would always be executed. In the new 'dummy' device in gossamer used by the simulator, this usb check returns false, so the simulator can't send data to the shell.

Seemed like a slightly cleaner thing to do was to call shell_task() regardless rather than to incorrectly pretend that USB was connected.