### PR TITLE
ported pulsometer_face and counter_face

### DIFF
--- a/movement_faces.h
+++ b/movement_faces.h
@@ -62,4 +62,6 @@
 #include "tally_face.h"
 #include "probability_face.h"
 #include "ke_decimal_time_face.h"
+#include "counter_face.h"
+#include "pulsometer_face.h"
 // New includes go above this line.

--- a/watch-faces.mk
+++ b/watch-faces.mk
@@ -37,4 +37,6 @@ SRCS += \
   ./watch-faces/complication/kitchen_conversions_face.c \
   ./watch-faces/complication/periodic_table_face.c \
   ./watch-faces/clock/ke_decimal_time_face.c \
+  ./watch-faces/complication/counter_face.c \
+  ./watch-faces/complication/pulsometer_face.c \
 # New watch faces go above this line.

--- a/watch-faces/complication/counter_face.c
+++ b/watch-faces/complication/counter_face.c
@@ -1,0 +1,153 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Shogo Okamoto
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "counter_face.h"
+#include "watch.h"
+#include "watch_utility.h"
+#include "watch_common_display.h"
+
+static inline bool lcd_is_custom(void) {
+    return watch_get_lcd_type() == WATCH_LCD_TYPE_CUSTOM;
+}
+
+void counter_face_setup(uint8_t watch_face_index, void ** context_ptr) {
+    (void) watch_face_index;
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(counter_state_t));
+        memset(*context_ptr, 0, sizeof(counter_state_t));
+        counter_state_t *state = (counter_state_t *)*context_ptr;
+        state->beep_on = true;
+    }
+}
+
+void counter_face_activate(void *context) {
+    counter_state_t *state = (counter_state_t *)context;
+    if (state->beep_on) {
+        watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+    }
+}
+
+bool counter_face_loop(movement_event_t event, void *context) {
+
+    counter_state_t *state = (counter_state_t *)context;
+
+    switch (event.event_type) {
+        case EVENT_ALARM_BUTTON_UP:
+            watch_buzzer_abort_sequence(); //abort running buzzer sequence when counting fast
+            state->counter_idx++; // increment counter index
+            if (state->counter_idx>99) { //0-99
+                state->counter_idx=0;//reset counter index
+            }
+            print_counter(state);
+            if (state->beep_on) {
+                beep_counter(state);
+            }
+            break;
+        case EVENT_LIGHT_LONG_PRESS:
+            watch_buzzer_abort_sequence();
+            state->beep_on = !state->beep_on;
+            if (state->beep_on) {
+                watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+            } else {
+                watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+            }
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            state->counter_idx=0; // reset counter index
+            print_counter(state);
+            break;
+        case EVENT_ACTIVATE:
+            print_counter(state);
+            break;
+        case EVENT_TIMEOUT:
+            // ignore timeout
+            break;
+        default:
+            movement_default_loop_handler(event);
+            break;
+    }
+
+    return true;
+}
+
+// beep counter index times
+void beep_counter(counter_state_t *state) {
+    int low_count = state->counter_idx/5;
+    int high_count = state->counter_idx - low_count * 5;
+    static int8_t sound_seq[15];
+    memset(sound_seq, 0, 15);
+    int i = 0;
+    if (low_count > 0) {
+        sound_seq[i] = BUZZER_NOTE_A6;
+        i++;
+        sound_seq[i] = 3;
+        i++;
+        sound_seq[i] = BUZZER_NOTE_REST;
+        i++;
+        sound_seq[i] = 6;
+        i++;
+        if (low_count > 1) {
+            sound_seq[i] = -2;
+            i++;
+            sound_seq[i] = low_count-1;
+            i++;
+        }
+        sound_seq[i] = BUZZER_NOTE_REST;
+        i++;
+        sound_seq[i] = 6;
+        i++;
+    }
+    if (high_count > 0) {
+        sound_seq[i] = BUZZER_NOTE_B6;
+        i++;
+        sound_seq[i] = 3;
+        i++;
+        sound_seq[i] = BUZZER_NOTE_REST;
+        i++;
+        sound_seq[i] = 6;
+        i++;
+    }
+    if (high_count > 1) {
+        sound_seq[i] = -2;
+        i++;
+        sound_seq[i] = high_count-1;
+    }
+    watch_buzzer_play_sequence((int8_t *)sound_seq, NULL);
+}
+
+
+// print counter index at the center of display.
+void print_counter(counter_state_t *state) {
+    char buf[14];
+    watch_display_text_with_fallback(WATCH_POSITION_TOP, "COUNT", "CO");
+    sprintf(buf, "  %02d", state->counter_idx); // center of LCD display
+    watch_display_text_with_fallback(WATCH_POSITION_BOTTOM, buf, buf);
+
+}
+
+void counter_face_resign(void *context) {
+    (void) context;
+}

--- a/watch-faces/complication/counter_face.h
+++ b/watch-faces/complication/counter_face.h
@@ -1,0 +1,63 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Shogo Okamoto
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef COUNTER_FACE_H_
+#define COUNTER_FACE_H_
+
+/*
+ * COUNTER face
+ *
+ * Counter face is designed to count the number of running laps during exercises.
+ *
+ * Usage:
+ * Short-press ALARM to increment the counter (loops at 99)
+ * Long-press ALARM to reset the counter.
+ * Long-press LIGHT to toggle sound.
+ */
+
+#include "movement.h"
+
+typedef struct {
+    uint8_t counter_idx;
+    bool beep_on;
+} counter_state_t;
+
+
+void counter_face_setup(uint8_t watch_face_index, void ** context_ptr);
+void counter_face_activate(void *context);
+bool counter_face_loop(movement_event_t event, void *context);
+void counter_face_resign(void *context);
+
+void print_counter(counter_state_t *state);
+void beep_counter(counter_state_t *state);
+
+#define counter_face ((const watch_face_t){ \
+    counter_face_setup, \
+    counter_face_activate, \
+    counter_face_loop, \
+    counter_face_resign, \
+    NULL, \
+})
+
+#endif // COUNTER_FACE_H_

--- a/watch-faces/complication/pulsometer_face.c
+++ b/watch-faces/complication/pulsometer_face.c
@@ -1,0 +1,215 @@
+/* SPDX-License-Identifier: MIT */
+
+/*
+ * MIT License
+ *
+ * Copyright © 2021-2022 Joey Castillo <joeycastillo@utexas.edu> <jose.castillo@gmail.com>
+ * Copyright © 2023 Jeremy O'Brien <neutral@fastmail.com>
+ * Copyright © 2024 Matheus Afonso Martins Moreira <matheus.a.m.moreira@gmail.com> (https://www.matheusmoreira.com/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "pulsometer_face.h"
+#include "watch.h"
+#include "watch_common_display.h"
+
+#ifndef PULSOMETER_FACE_CALIBRATION_DEFAULT
+#define PULSOMETER_FACE_CALIBRATION_DEFAULT (30)
+#endif
+
+#ifndef PULSOMETER_FACE_CALIBRATION_INCREMENT
+#define PULSOMETER_FACE_CALIBRATION_INCREMENT (10)
+#endif
+
+// tick frequency will be 2 to this power Hz (0 for 1 Hz, 2 for 4 Hz, etc.)
+#ifndef PULSOMETER_FACE_FREQUENCY_FACTOR
+#define PULSOMETER_FACE_FREQUENCY_FACTOR (4ul)
+#endif
+
+#define PULSOMETER_FACE_FREQUENCY (1 << PULSOMETER_FACE_FREQUENCY_FACTOR)
+
+typedef struct {
+    bool measuring;
+    int16_t pulses;
+    int16_t ticks;
+    int8_t calibration;
+} pulsometer_state_t;
+
+static inline bool lcd_is_custom(void) {
+    return watch_get_lcd_type() == WATCH_LCD_TYPE_CUSTOM;
+}
+
+static void pulsometer_display_title(pulsometer_state_t *pulsometer) {
+    (void) pulsometer;
+    watch_display_text_with_fallback(WATCH_POSITION_TOP, "PULSE", "PL");
+}
+
+static void pulsometer_display_calibration(pulsometer_state_t *pulsometer) {
+    char buf[3];
+    if (lcd_is_custom()) {
+        snprintf(buf, sizeof(buf), "%2hhd", pulsometer->calibration);
+        watch_display_text(WATCH_POSITION_SECONDS, buf);
+    } else {
+        snprintf(buf, sizeof(buf), "%2hhd", pulsometer->calibration);
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+    }
+}
+
+static void pulsometer_display_measurement(pulsometer_state_t *pulsometer) {
+    if (lcd_is_custom()) {
+    char buf[5];
+    int16_t value = pulsometer->pulses;
+
+    if (value > 9999) value = 9999;
+
+    snprintf(buf, sizeof(buf), "%-4hd", value);
+    watch_display_text(WATCH_POSITION_BOTTOM, buf);
+    } else {
+        char buf[7];
+        snprintf(buf, sizeof(buf), "%-6hd", pulsometer->pulses);
+        watch_display_text(WATCH_POSITION_BOTTOM, buf);
+    }  
+}
+
+static void pulsometer_indicate(pulsometer_state_t *pulsometer) {
+    if (pulsometer->measuring) {
+        watch_set_indicator(WATCH_INDICATOR_LAP);
+    } else {
+        watch_clear_indicator(WATCH_INDICATOR_LAP);
+    }
+}
+
+static void pulsometer_start_measurement(pulsometer_state_t *pulsometer) {
+    pulsometer->measuring = true;
+    pulsometer->pulses = INT16_MAX;
+    pulsometer->ticks = 0;
+
+    pulsometer_indicate(pulsometer);
+
+    movement_request_tick_frequency(PULSOMETER_FACE_FREQUENCY);
+}
+
+static void pulsometer_measure(pulsometer_state_t *pulsometer) {
+    if (!pulsometer->measuring) { return; }
+
+    pulsometer->ticks++;
+
+    float ticks_per_minute = 60 << PULSOMETER_FACE_FREQUENCY_FACTOR;
+    float pulses_while_button_held = ticks_per_minute / pulsometer->ticks;
+    float calibrated_pulses = pulses_while_button_held * pulsometer->calibration;
+    calibrated_pulses += 0.5f;
+
+    pulsometer->pulses = (int16_t) calibrated_pulses;
+
+    pulsometer_display_measurement(pulsometer);
+}
+
+static void pulsometer_stop_measurement(pulsometer_state_t *pulsometer) {
+    movement_request_tick_frequency(1);
+
+    pulsometer->measuring = false;
+
+    pulsometer_display_measurement(pulsometer);
+    pulsometer_indicate(pulsometer);
+}
+
+static void pulsometer_cycle_calibration(pulsometer_state_t *pulsometer, int8_t increment) {
+    if (pulsometer->measuring) { return; }
+
+    if (pulsometer->calibration <= 0) {
+        pulsometer->calibration = 1;
+    }
+
+    int8_t last = pulsometer->calibration;
+    pulsometer->calibration += increment;
+
+    if (pulsometer->calibration > 39) {
+        pulsometer->calibration = last == 39? 1 : 39;
+    }
+
+    pulsometer_display_calibration(pulsometer);
+}
+
+void pulsometer_face_setup(uint8_t watch_face_index, void ** context_ptr) {
+    (void) watch_face_index;
+
+    if (*context_ptr == NULL) {
+        pulsometer_state_t *pulsometer = malloc(sizeof(pulsometer_state_t));
+
+        pulsometer->calibration = PULSOMETER_FACE_CALIBRATION_DEFAULT;
+        pulsometer->pulses = 0;
+        pulsometer->ticks = 0;
+
+        *context_ptr = pulsometer;
+    }
+}
+
+void pulsometer_face_activate(void *context) {
+
+    pulsometer_state_t *pulsometer = context;
+
+    pulsometer->measuring = false;
+
+    pulsometer_display_title(pulsometer);
+    pulsometer_display_calibration(pulsometer);
+    pulsometer_display_measurement(pulsometer);
+}
+
+bool pulsometer_face_loop(movement_event_t event,void *context) {
+
+    pulsometer_state_t *pulsometer = (pulsometer_state_t *) context;
+
+    switch (event.event_type) {
+        case EVENT_ALARM_BUTTON_DOWN:
+            pulsometer_start_measurement(pulsometer);
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+        case EVENT_ALARM_LONG_UP:
+            pulsometer_stop_measurement(pulsometer);
+            break;
+        case EVENT_TICK:
+            pulsometer_measure(pulsometer);
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            pulsometer_cycle_calibration(pulsometer, 1);
+            break;
+        case EVENT_LIGHT_LONG_UP:
+            pulsometer_cycle_calibration(pulsometer, PULSOMETER_FACE_CALIBRATION_INCREMENT);
+            break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            // Inhibit the LED
+            break;
+        case EVENT_TIMEOUT:
+            movement_move_to_face(0);
+            break;
+        default:
+            movement_default_loop_handler(event);
+            break;
+    }
+
+    return true;
+}
+
+void pulsometer_face_resign(void *context) {
+    (void) context;
+}

--- a/watch-faces/complication/pulsometer_face.h
+++ b/watch-faces/complication/pulsometer_face.h
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: MIT */
+
+/*
+ * MIT License
+ *
+ * Copyright © 2021-2022 Joey Castillo <joeycastillo@utexas.edu> <jose.castillo@gmail.com>
+ * Copyright © 2022 Alexsander Akers <me@a2.io>
+ * Copyright © 2023 Alex Utter <ooterness@gmail.com>
+ * Copyright © 2024 Matheus Afonso Martins Moreira <matheus.a.m.moreira@gmail.com> (https://www.matheusmoreira.com/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef PULSOMETER_FACE_H_
+#define PULSOMETER_FACE_H_
+
+/*
+ * PULSOMETER face
+ *
+ * The pulsometer implements a classic mechanical watch complication.
+ * A mechanical pulsometer involves a chronograph with a scale that
+ * allows the user to compute the number of heart beats per minute
+ * in less time. The scale is calibrated, or graduated, for a fixed
+ * number of heart beats, most often 30. The user starts the chronograph
+ * and simultaneously begins counting the heart beats. The movement of
+ * the chronograph's seconds hand over time automatically performs the
+ * computations required. When the calibrated number of heart beats
+ * is reached, the chronograph is stopped and the seconds hand shows
+ * the heart rate.
+ *
+ * The Sensor Watch pulsometer improves this design with user calibration:
+ * it can be graduated to any value between 1 and 39 pulsations per minute.
+ * The default is still 30, mirroring the classic pulsometer calibration.
+ * This feature allows the user to reconfigure the pulsometer to count
+ * many other types of periodic minutely events, making it more versatile.
+ * For example, it can be set to 5 respirations per minute to turn it into
+ * an asthmometer, a nearly identical mechanical watch complication
+ * that doctors might use to quickly measure respiratory rate.
+ *
+ * To use the pulsometer, hold the ALARM button and count the pulses.
+ * When the calibrated number of pulses is reached, release the button.
+ * The display will show the number of pulses per minute.
+ *
+ * In order to measure heart rate, feel for a pulse using the hand with
+ * the watch while holding the button down with the other.
+ * The pulse can be easily felt on the carotid artery of the neck.
+ *
+ * In order to measure breathing rate, simply hold the ALARM button
+ * and count the number of breaths.
+ *
+ * To calibrate the pulsometer, press LIGHT
+ * to cycle to the next integer calibration.
+ * Long press LIGHT to cycle it by 10.
+ */
+
+#include "movement.h"
+
+void pulsometer_face_setup(uint8_t watch_face_index, void ** context_ptr);
+void pulsometer_face_activate(void *context);
+bool pulsometer_face_loop(movement_event_t event,void *context);
+void pulsometer_face_resign(void *context);
+
+#define pulsometer_face ((const watch_face_t){ \
+    pulsometer_face_setup, \
+    pulsometer_face_activate, \
+    pulsometer_face_loop, \
+    pulsometer_face_resign, \
+    NULL, \
+})
+
+#endif // PULSOMETER_FACE_H_


### PR DESCRIPTION
also optimized it for the custom LCD:

Pulsometer now reads PULSE in the top row and calibration has been moved to the bottom row (seconds field). Max. pulses shown are now limited to 9999 (only on custom LCD) so as not to interfere with the calibration counter. 

Counter now shows COUNt in the top row.