### PR TITLE
Fix simulator deep sleep mode

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -51,6 +51,7 @@
 
 #if __EMSCRIPTEN__
 #include <emscripten.h>
+void _wake_up_simulator(void);
 #else
 #include "watch_usb_cdc.h"
 #endif
@@ -1023,6 +1024,10 @@ void cb_alarm_btn_extwake(void) {
 }
 
 void cb_alarm_fired(void) {
+#if __EMSCRIPTEN__
+    _wake_up_simulator();
+#endif
+
     movement_state.woke_from_alarm_handler = true;
 }
 

--- a/watch-library/simulator/watch/watch_deepsleep.c
+++ b/watch-library/simulator/watch/watch_deepsleep.c
@@ -25,17 +25,37 @@
 #include <stddef.h>
 #include "watch_extint.h"
 #include "app.h"
+#include <emscripten.h>
+
 static uint32_t watch_backup_data[8];
+
+static bool _wake_up = false;
+static watch_cb_t _callback = NULL;
+
+
+void _wake_up_simulator(void) {
+    _wake_up = true;
+}
+
+static void cb_extwake_wrapper(void) {
+    _wake_up_simulator();
+
+    if (_callback) {
+        _callback();
+    }
+}
 
 void watch_register_extwake_callback(uint8_t pin, watch_cb_t callback, bool level) {
     if (pin == HAL_GPIO_BTN_ALARM_pin()) {
+        _callback = callback;
         watch_enable_external_interrupts();
-        watch_register_interrupt_callback(pin, callback, level ? INTERRUPT_TRIGGER_RISING : INTERRUPT_TRIGGER_FALLING);
+        watch_register_interrupt_callback(pin, cb_extwake_wrapper, level ? INTERRUPT_TRIGGER_RISING : INTERRUPT_TRIGGER_FALLING);
     }
 }
 
 void watch_disable_extwake_interrupt(uint8_t pin) {
     if (pin == HAL_GPIO_BTN_ALARM_pin()) {
+        _callback = NULL;
         watch_register_interrupt_callback(pin, NULL, INTERRUPT_TRIGGER_NONE);
     }
 }
@@ -57,23 +77,33 @@ uint32_t watch_get_backup_data(uint8_t reg) {
 void watch_enter_sleep_mode(void) {
     // TODO: (a2) hook to UI
 
-    // enter standby (4); we basically hang out here until an interrupt wakes us.
-    // sleep(4);
+    // disable tick interrupt
+    watch_rtc_disable_all_periodic_callbacks();
+
+    // // disable all buttons but alarm
+    watch_register_interrupt_callback(HAL_GPIO_BTN_MODE_pin(), NULL, INTERRUPT_TRIGGER_NONE);
+    watch_register_interrupt_callback(HAL_GPIO_BTN_LIGHT_pin(), NULL, INTERRUPT_TRIGGER_NONE);
+
+    sleep(4);
 
     // call app_setup so the app can re-enable everything we disabled.
     app_setup();
-}
-
-void watch_enter_deep_sleep_mode(void) {
-    // identical to sleep mode except we disable the LCD first.
-    // TODO: (a2) hook to UI
-
-    watch_enter_sleep_mode();
 }
 
 void watch_enter_backup_mode(void) {
     // TODO: (a2) hook to UI
 
     // go into backup sleep mode (5). when we exit, the reset controller will take over.
-    // sleep(5);
+    sleep(5);
+}
+
+void sleep(const uint8_t mode) {
+    (void) mode;
+
+    // we basically hang out here until an interrupt wakes us.
+    while(!_wake_up) {
+        emscripten_sleep(100);
+    }
+
+    _wake_up = false;
 }


### PR DESCRIPTION
For as long as I can remember, deep sleep has been broken in the simulator, causing the browser to enter into an infinite high cpu usage loop.

This PR addresses that.