### PR TITLE
Fix set_time_face erroneously setting the local time when changing timezone

### DIFF
--- a/watch-faces/settings/set_time_face.c
+++ b/watch-faces/settings/set_time_face.c
@@ -44,7 +44,7 @@ static void _handle_alarm_button(watch_date_time_t date_time, uint8_t current_pa
             movement_set_timezone_index(movement_get_timezone_index() + 1);
             if (movement_get_timezone_index() >= NUM_ZONE_NAMES) movement_set_timezone_index(0);
             current_offset = movement_get_current_timezone_offset_for_zone(movement_get_timezone_index());
-            break;
+            return;
         case 0: // year
             date_time.unit.year = ((date_time.unit.year % 60) + 1);
             break;


### PR DESCRIPTION
It's easier to explain this issue with an example:

- The watch is set to 9:00 on NY timezone
- I travel to LA and want to switch to the local time there
- I switch the timezone to LA and expect the time to show that it is 6:00
- But the set_time_face also resets the previous local time after setting the timezone, so the displayed time will still be 9:00

This one liner fixes this issue