### PR TITLE
Fix stopwatch_face day counter not resetting

### DIFF
--- a/watch-faces/complication/stopwatch_face.c
+++ b/watch-faces/complication/stopwatch_face.c
@@ -114,6 +114,7 @@ bool stopwatch_face_loop(movement_event_t event, void *context) {
                 stopwatch_state->start_time.reg = 0;
                 stopwatch_state->seconds_counted = 0;
                 watch_display_text(WATCH_POSITION_BOTTOM, "000000");
+                watch_display_text(WATCH_POSITION_TOP_RIGHT, "  ");
             }
             break;
         case EVENT_ALARM_BUTTON_DOWN:


### PR DESCRIPTION
When resetting the stopwatch, the day counter (top right field) was not being cleared, causing it to persist after reset. This fix ensures the day field is properly cleared along with the time fields when the stopwatch is reset.

Fixes #51 