### PR TITLE
Let users adjust the volume of (almost) all sounds

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -45,6 +45,7 @@
 #include "delay.h"
 #include "thermistor_driver.h"
 
+#define MOVEMENT_C_
 #include "movement_config.h"
 
 #include "movement_custom_signal_tunes.h"

--- a/movement.c
+++ b/movement.c
@@ -45,7 +45,6 @@
 #include "delay.h"
 #include "thermistor_driver.h"
 
-#define MOVEMENT_C_
 #include "movement_config.h"
 
 #include "movement_custom_signal_tunes.h"
@@ -434,12 +433,22 @@ void movement_set_button_should_sound(bool value) {
     movement_state.settings.bit.button_should_sound = value;
 }
 
-watch_buzzer_volume_t movement_button_volume(void) {
-    return movement_state.settings.bit.button_volume;
+watch_buzzer_volume_t movement_volume(void) {
+    return movement_state.settings.bit.volume;
 }
 
+void movement_set_volume(watch_buzzer_volume_t value) {
+    movement_state.settings.bit.volume = value;
+}
+
+/* Deprecated. */
+watch_buzzer_volume_t movement_button_volume(void) {
+    return movement_volume();
+}
+
+/* Deprecated. */
 void movement_set_button_volume(watch_buzzer_volume_t value) {
-    movement_state.settings.bit.button_volume = value;
+    movement_set_volume(value);
 }
 
 movement_clock_mode_t movement_clock_mode_24h(void) {
@@ -654,7 +663,7 @@ void app_init(void) {
         movement_state.settings.bit.led_blue_color = MOVEMENT_DEFAULT_BLUE_COLOR;
     #endif
         movement_state.settings.bit.button_should_sound = MOVEMENT_DEFAULT_BUTTON_SOUND;
-        movement_state.settings.bit.button_volume = MOVEMENT_DEFAULT_BUTTON_VOLUME;
+        movement_state.settings.bit.volume = MOVEMENT_DEFAULT_BUTTON_VOLUME;
         movement_state.settings.bit.to_interval = MOVEMENT_DEFAULT_TIMEOUT_INTERVAL;
 #ifdef MOVEMENT_LOW_ENERGY_MODE_FORBIDDEN
         movement_state.settings.bit.le_interval = 0;
@@ -835,7 +844,7 @@ bool app_loop(void) {
     if (movement_state.watch_face_changed) {
         if (movement_state.settings.bit.button_should_sound) {
             // low note for nonzero case, high note for return to watch_face 0
-            watch_buzzer_play_note_with_volume(movement_state.next_face_idx ? BUZZER_NOTE_C7 : BUZZER_NOTE_C8, 50, movement_state.settings.bit.button_volume);
+            watch_buzzer_play_note_with_volume(movement_state.next_face_idx ? BUZZER_NOTE_C7 : BUZZER_NOTE_C8, 50, movement_state.settings.bit.volume);
         }
         wf->resign(watch_face_contexts[movement_state.current_face_idx]);
         movement_state.current_face_idx = movement_state.next_face_idx;

--- a/movement.c
+++ b/movement.c
@@ -451,6 +451,12 @@ void movement_set_button_volume(watch_buzzer_volume_t value) {
     movement_set_volume(value);
 }
 
+void movement_play_button_sound_if_enabled(void) {
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note(BUZZER_NOTE_C7, 50);
+    }
+}
+
 movement_clock_mode_t movement_clock_mode_24h(void) {
     return movement_state.settings.bit.clock_mode_24h ? MOVEMENT_CLOCK_MODE_24H : MOVEMENT_CLOCK_MODE_12H;
 }

--- a/movement.h
+++ b/movement.h
@@ -353,6 +353,11 @@ void movement_set_volume(watch_buzzer_volume_t value);
 watch_buzzer_volume_t movement_button_volume(void) __attribute__ ((deprecated("Use movement_volume().")));
 void movement_set_button_volume(watch_buzzer_volume_t value) __attribute__ ((deprecated("Use movement_set_volume().")));
 
+/** @brief Plays standard button sound, but only if beeps are turned on.
+  * @details The standard sound is BUZZER_NOTE_C7, played for 50 ms.
+  */
+void movement_play_button_sound_if_enabled(void);
+
 movement_clock_mode_t movement_clock_mode_24h(void);
 void movement_set_clock_mode_24h(movement_clock_mode_t value);
 

--- a/movement.h
+++ b/movement.h
@@ -84,7 +84,7 @@ typedef union {
         bool clock_mode_24h : 1;            // indicates whether clock should use 12 or 24 hour mode.
         bool use_imperial_units : 1;        // indicates whether to use metric units (the default) or imperial.
         
-        bool button_volume : 1;             // 0 for soft beep, 1 for loud beep. If button_should_sound (above) is false, this is ignored.
+        bool volume : 1;                    // 0 for soft beep, 1 for loud beep.
     } bit;
     uint32_t reg;
 } movement_settings_t;
@@ -345,8 +345,13 @@ void movement_set_local_date_time(watch_date_time_t date_time);
 bool movement_button_should_sound(void);
 void movement_set_button_should_sound(bool value);
 
-watch_buzzer_volume_t movement_button_volume(void);
-void movement_set_button_volume(watch_buzzer_volume_t value);
+/** @brief The volume level used both for button and other sounds.
+  */
+watch_buzzer_volume_t movement_volume(void);
+void movement_set_volume(watch_buzzer_volume_t value);
+
+watch_buzzer_volume_t movement_button_volume(void) __attribute__ ((deprecated("Use movement_volume().")));
+void movement_set_button_volume(watch_buzzer_volume_t value) __attribute__ ((deprecated("Use movement_set_volume().")));
 
 movement_clock_mode_t movement_clock_mode_24h(void);
 void movement_set_clock_mode_24h(movement_clock_mode_t value);

--- a/movement_config.h
+++ b/movement_config.h
@@ -27,7 +27,6 @@
 
 #include "movement_faces.h"
 
-#ifdef MOVEMENT_C_
 const watch_face_t watch_faces[] = {
     clock_face,
     world_clock_face,
@@ -41,7 +40,6 @@ const watch_face_t watch_faces[] = {
     settings_face,
     set_time_face
 };
-#endif
 
 #define MOVEMENT_NUM_FACES (sizeof(watch_faces) / sizeof(watch_face_t))
 

--- a/movement_config.h
+++ b/movement_config.h
@@ -27,6 +27,7 @@
 
 #include "movement_faces.h"
 
+#ifdef MOVEMENT_C_
 const watch_face_t watch_faces[] = {
     clock_face,
     world_clock_face,
@@ -40,6 +41,7 @@ const watch_face_t watch_faces[] = {
     settings_face,
     set_time_face
 };
+#endif
 
 #define MOVEMENT_NUM_FACES (sizeof(watch_faces) / sizeof(watch_face_t))
 

--- a/watch-faces/complication/alarm_face.c
+++ b/watch-faces/complication/alarm_face.c
@@ -50,11 +50,6 @@ static void _alarm_face_display_alarm_time(alarm_face_state_t *state) {
     watch_display_text(WATCH_POSITION_BOTTOM, lcdbuf);
 }
 
-static inline void button_beep() {
-    // play a beep as confirmation for a button press (if applicable)
-    if (movement_button_should_sound()) watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
-}
-
 //
 // Exported
 //
@@ -115,7 +110,7 @@ bool alarm_face_loop(movement_event_t event, void *context) {
                     state->setting_mode = ALARM_FACE_SETTING_MODE_NONE;
                     movement_request_tick_frequency(1);
                     // beep to confirm setting.
-                    button_beep();
+                    movement_play_button_sound_if_enabled();
                     // also turn the alarm on since they just set it.
                     state->alarm_is_on = 1;
                     movement_set_alarm_enabled(true);
@@ -158,7 +153,7 @@ bool alarm_face_loop(movement_event_t event, void *context) {
                 // long press in normal mode: move to hour setting mode, request fast tick.
                 state->setting_mode = ALARM_FACE_SETTING_MODE_SETTING_HOUR;
                 movement_request_tick_frequency(4);
-                button_beep();
+                movement_play_button_sound_if_enabled();
             }
             break;
         case EVENT_BACKGROUND_TASK:

--- a/watch-faces/complication/countdown_face.c
+++ b/watch-faces/complication/countdown_face.c
@@ -65,11 +65,6 @@ static inline void load_countdown(countdown_state_t *state) {
     state->seconds = state->set_seconds;
 }
 
-static inline void button_beep() {
-    // play a beep as confirmation for a button press (if applicable)
-    if (movement_button_should_sound()) watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
-}
-
 static void schedule_countdown(countdown_state_t *state) {
 
     // Calculate the new state->now_ts but don't update it until we've updated the target - 
@@ -264,7 +259,7 @@ bool countdown_face_loop(movement_event_t event, void *context) {
                     break;
                 case cd_paused:
                     reset(state);
-                    button_beep();
+                    movement_play_button_sound_if_enabled();
                     break;
                 case cd_setting:
                     state->selection++;
@@ -273,7 +268,7 @@ bool countdown_face_loop(movement_event_t event, void *context) {
                         state->mode = cd_reset;
                         store_countdown(state);
                         movement_request_tick_frequency(1);
-                        button_beep();
+                        movement_play_button_sound_if_enabled();
                     }
                     break;
             }
@@ -283,7 +278,7 @@ bool countdown_face_loop(movement_event_t event, void *context) {
             switch(state->mode) {
                 case cd_running:
                     pause(state);
-                    button_beep();
+                    movement_play_button_sound_if_enabled();
                     break;
                 case cd_reset:
                 case cd_paused:
@@ -291,7 +286,7 @@ bool countdown_face_loop(movement_event_t event, void *context) {
                     if (!(state->hours == 0 && state->minutes == 0 && state->seconds == 0)) {
                         abort_tap_detection(state);
                         start(state);
-                        button_beep();
+                        movement_play_button_sound_if_enabled();
                         watch_set_indicator(WATCH_INDICATOR_SIGNAL);
                     }
                     break;
@@ -308,7 +303,7 @@ bool countdown_face_loop(movement_event_t event, void *context) {
                     abort_tap_detection(state);
                     state->mode = cd_setting;
                     movement_request_tick_frequency(4);
-                    button_beep();
+                    movement_play_button_sound_if_enabled();
                     break;
                 case cd_setting:
                     // long press in settings mode starts quick ticks for adjusting the time
@@ -336,7 +331,7 @@ bool countdown_face_loop(movement_event_t event, void *context) {
                 }
             } else {
                 // Toggle auto-repeat
-                button_beep();
+                movement_play_button_sound_if_enabled();
                 state->repeat = !state->repeat;
                 if(state->repeat)
                     watch_set_indicator(WATCH_INDICATOR_BELL);

--- a/watch-faces/complication/fast_stopwatch_face.c
+++ b/watch-faces/complication/fast_stopwatch_face.c
@@ -119,11 +119,6 @@ void irq_handler_tc1(void) {
 
 #endif
 
-static inline void _button_beep() {
-    // play a beep as confirmation for a button press (if applicable)
-    if (movement_button_should_sound()) watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
-}
-
 /// @brief Display minutes, seconds and fractions derived from 128 Hz tick counter
 ///        on the lcd.
 /// @param ticks
@@ -280,7 +275,7 @@ bool fast_stopwatch_face_loop(movement_event_t event, void *context) {
                 movement_cancel_background_task();
             }
             _draw();
-            _button_beep();
+            movement_play_button_sound_if_enabled();
             break;
         case EVENT_LIGHT_BUTTON_DOWN:
             if (state->light_on_button) movement_illuminate_led();
@@ -302,7 +297,7 @@ bool fast_stopwatch_face_loop(movement_event_t event, void *context) {
                 } else if (_ticks) {
                     // reset stopwatch
                     _ticks = _lap_ticks = _blink_ticks = _old_minutes = _old_seconds = _hours = 0;
-                    _button_beep();
+                    movement_play_button_sound_if_enabled();
                 }
             }
             _display_ticks(_ticks);

--- a/watch-faces/complication/stopwatch_face.c
+++ b/watch-faces/complication/stopwatch_face.c
@@ -117,9 +117,7 @@ bool stopwatch_face_loop(movement_event_t event, void *context) {
             }
             break;
         case EVENT_ALARM_BUTTON_DOWN:
-            if (movement_button_should_sound()) {
-                watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
-            }
+            movement_play_button_sound_if_enabled();
             stopwatch_state->running = !stopwatch_state->running;
             if (stopwatch_state->running) {
                 // we're running now, so we need to set the start_time.

--- a/watch-faces/settings/settings_face.c
+++ b/watch-faces/settings/settings_face.c
@@ -58,7 +58,7 @@ static void beep_setting_advance(void) {
         /* Was muted.  Unmute. */
         movement_set_button_should_sound(true);
         beep_setting_display(1);
-        watch_buzzer_play_note(BUZZER_NOTE_C7, 50);
+        movement_play_button_sound_if_enabled();
     }
 }
 

--- a/watch-faces/settings/settings_face.c
+++ b/watch-faces/settings/settings_face.c
@@ -42,38 +42,68 @@ static void beep_setting_display(uint8_t subsecond) {
     watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "BTN", "BT");
     watch_display_text_with_fallback(WATCH_POSITION_BOTTOM, "beep  ", " beep ");
     if (subsecond % 2) {
-        if (movement_button_should_sound()) {
-            if (movement_button_volume() == WATCH_BUZZER_VOLUME_LOUD) {
-                // H for HIGH
-                watch_display_text(WATCH_POSITION_TOP_RIGHT, " H");
-            }
-            else {
-                // L for LOW
-                watch_display_text(WATCH_POSITION_TOP_RIGHT, " L");
-            }
-        } else {
-            // N for NONE
-            watch_display_text(WATCH_POSITION_TOP_RIGHT, " N");
-        }
+        watch_display_text(
+            WATCH_POSITION_TOP_RIGHT,
+            movement_button_should_sound() ? " Y" : " N"
+        );
     }
 }
 
 static void beep_setting_advance(void) {
-    if (!movement_button_should_sound()) {
-        // was muted. make it soft.
-        movement_set_button_should_sound(true);
-        movement_set_button_volume(WATCH_BUZZER_VOLUME_SOFT);
-        beep_setting_display(1);
-        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, WATCH_BUZZER_VOLUME_SOFT);
-    } else if (movement_button_volume() == WATCH_BUZZER_VOLUME_SOFT) {
-        // was soft. make it loud.
-        movement_set_button_volume(WATCH_BUZZER_VOLUME_LOUD);
-        beep_setting_display(1);
-        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, WATCH_BUZZER_VOLUME_LOUD);
-    } else {
-        // was loud. make it silent.
+    if (movement_button_should_sound()) {
+        /* Was unmuted.  Mute. */
         movement_set_button_should_sound(false);
         beep_setting_display(1);
+    } else {
+        /* Was muted.  Unmute. */
+        movement_set_button_should_sound(true);
+        beep_setting_display(1);
+        watch_buzzer_play_note(BUZZER_NOTE_C7, 50);
+    }
+}
+
+static void volume_setting_display(uint8_t subsecond) {
+    watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "SND", "SD");
+    watch_display_text_with_fallback(WATCH_POSITION_BOTTOM, " VOL  ", " VOL  ");
+
+    if (subsecond % 2) {
+        char buf[3] = " E";
+
+        _Static_assert(WATCH_BUZZER_VOLUME_COUNT == 2, "unaccounted for volume level");
+
+        switch (movement_button_volume()) {
+            case WATCH_BUZZER_VOLUME_SOFT:
+                buf[1] = 'L';   /* Low */
+                break;
+            case WATCH_BUZZER_VOLUME_LOUD:
+                buf[1] = 'H';   /* High */
+                break;
+            default:    /* unreachable */
+                break;
+        }
+
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+    }
+}
+
+static void volume_setting_advance(void) {
+    _Static_assert(WATCH_BUZZER_VOLUME_COUNT == 2, "unaccounted for volume level");
+
+    switch (movement_button_volume()) {
+        case WATCH_BUZZER_VOLUME_SOFT:
+            /* Was soft. make it loud. */
+            movement_set_button_volume(WATCH_BUZZER_VOLUME_LOUD);
+            volume_setting_display(1);
+            watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, WATCH_BUZZER_VOLUME_LOUD);
+            break;
+        case WATCH_BUZZER_VOLUME_LOUD:
+            /* Was loud, make it soft. */
+            movement_set_button_volume(WATCH_BUZZER_VOLUME_SOFT);
+            volume_setting_display(1);
+            watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, WATCH_BUZZER_VOLUME_SOFT);
+            break;
+        default:    /* unreachable */
+            break;
     }
 }
 
@@ -255,6 +285,9 @@ void settings_face_setup(uint8_t watch_face_index, void ** context_ptr) {
         current_setting++;
         state->settings_screens[current_setting].display = beep_setting_display;
         state->settings_screens[current_setting].advance = beep_setting_advance;
+        current_setting++;
+        state->settings_screens[current_setting].display = volume_setting_display;
+        state->settings_screens[current_setting].advance = volume_setting_advance;
         current_setting++;
         state->settings_screens[current_setting].display = timeout_setting_display;
         state->settings_screens[current_setting].advance = timeout_setting_advance;

--- a/watch-faces/settings/settings_face.c
+++ b/watch-faces/settings/settings_face.c
@@ -71,7 +71,7 @@ static void volume_setting_display(uint8_t subsecond) {
 
         _Static_assert(WATCH_BUZZER_VOLUME_COUNT == 2, "unaccounted for volume level");
 
-        switch (movement_button_volume()) {
+        switch (movement_volume()) {
             case WATCH_BUZZER_VOLUME_SOFT:
                 buf[1] = 'L';   /* Low */
                 break;
@@ -89,16 +89,16 @@ static void volume_setting_display(uint8_t subsecond) {
 static void volume_setting_advance(void) {
     _Static_assert(WATCH_BUZZER_VOLUME_COUNT == 2, "unaccounted for volume level");
 
-    switch (movement_button_volume()) {
+    switch (movement_volume()) {
         case WATCH_BUZZER_VOLUME_SOFT:
             /* Was soft. make it loud. */
-            movement_set_button_volume(WATCH_BUZZER_VOLUME_LOUD);
+            movement_set_volume(WATCH_BUZZER_VOLUME_LOUD);
             volume_setting_display(1);
             watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, WATCH_BUZZER_VOLUME_LOUD);
             break;
         case WATCH_BUZZER_VOLUME_LOUD:
             /* Was loud, make it soft. */
-            movement_set_button_volume(WATCH_BUZZER_VOLUME_SOFT);
+            movement_set_volume(WATCH_BUZZER_VOLUME_SOFT);
             volume_setting_display(1);
             watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, WATCH_BUZZER_VOLUME_SOFT);
             break;

--- a/watch-library/hardware/watch/watch_tcc.c
+++ b/watch-library/hardware/watch/watch_tcc.c
@@ -24,10 +24,9 @@
 
 #include "watch_tcc.h"
 #include "delay.h"
+#include "movement.h"
 #include "tcc.h"
 #include "tc.h"
-
-#include "movement_config.h"
 
 void _watch_enable_tcc(void);
 void cb_watch_buzzer_seq(void);
@@ -87,14 +86,6 @@ void watch_buzzer_play_sequence(int8_t *note_sequence, void (*callback_on_end)(v
     _tc0_start();
 }
 
-inline watch_buzzer_volume_t watch_buzzer_volume() {
-    if (movement_button_should_sound()) {
-        return movement_button_volume();
-    }
-
-    return MOVEMENT_DEFAULT_BUTTON_VOLUME;
-}
-
 static inline uint8_t volume_to_duty(watch_buzzer_volume_t volume) {
     _Static_assert(WATCH_BUZZER_VOLUME_COUNT == 2, "unaccounted for volume level");
 
@@ -130,7 +121,7 @@ void cb_watch_buzzer_seq(void) {
             // read note
             watch_buzzer_note_t note = _sequence[_seq_position];
             if (note != BUZZER_NOTE_REST) {
-                watch_buzzer_volume_t volume = watch_buzzer_volume();
+                watch_buzzer_volume_t volume = movement_volume();
                 uint8_t duty = volume_to_duty(volume);
                 watch_set_buzzer_period_and_duty_cycle(NotePeriods[note], duty);
                 watch_set_buzzer_on();
@@ -190,7 +181,7 @@ inline void watch_set_buzzer_off(void) {
 }
 
 void watch_buzzer_play_note(watch_buzzer_note_t note, uint16_t duration_ms) {
-    watch_buzzer_play_note_with_volume(note, duration_ms, watch_buzzer_volume());
+    watch_buzzer_play_note_with_volume(note, duration_ms, movement_volume());
 }
 
 void watch_buzzer_play_note_with_volume(watch_buzzer_note_t note, uint16_t duration_ms, watch_buzzer_volume_t volume) {

--- a/watch-library/shared/watch/watch_tcc.h
+++ b/watch-library/shared/watch/watch_tcc.h
@@ -31,7 +31,8 @@
 /// @brief An enum for controlling the volume of the buzzer.
 typedef enum {
     WATCH_BUZZER_VOLUME_SOFT = 0,
-    WATCH_BUZZER_VOLUME_LOUD
+    WATCH_BUZZER_VOLUME_LOUD,
+    WATCH_BUZZER_VOLUME_COUNT
 } watch_buzzer_volume_t;
 
 /// @brief 87 notes for use with watch_buzzer_play_note
@@ -167,11 +168,17 @@ void watch_set_buzzer_on(void);
   */
 void watch_set_buzzer_off(void);
 
-/** @brief Plays the given note for a set duration at the loudest possible volume.
+/** @brief Returns the volume at which the buzzer should sound.
+  * @return If button sounds are turned on, then the currently configured volume. Otherwise,
+  *         MOVEMENT_DEFAULT_BUTTON_VOLUME.
+  */
+watch_buzzer_volume_t watch_buzzer_volume(void);
+
+/** @brief Plays the given note for a set duration at the currently configured volume.
   * @param note The note you wish to play, or BUZZER_NOTE_REST to disable output for the given duration.
   * @param duration_ms The duration of the note.
-  * @note Note that this will block your UI for the duration of the note's play time, and it will
-  *       after this call, the buzzer period will be set to the period of this note.
+  * @note This will block your UI for the duration of the note's play time, and after this call, the
+  *       buzzer will stop sounding, but the TCC period will remain set to the period of this note.
   */
 void watch_buzzer_play_note(watch_buzzer_note_t note, uint16_t duration_ms);
 
@@ -187,7 +194,7 @@ void watch_buzzer_play_note_with_volume(watch_buzzer_note_t note, uint16_t durat
 /// @brief An array of periods for all the notes on a piano, corresponding to the names in watch_buzzer_note_t.
 extern const uint16_t NotePeriods[108];
 
-/** @brief Plays the given sequence of notes in a non-blocking way.
+/** @brief Plays the given sequence of notes in a non-blocking way, at the currently configured volume.
   * @param note_sequence A pointer to the sequence of buzzer note & duration tuples, ending with a zero. A simple
   *        RLE logic is implemented: a negative number instead of a buzzer note means that the sequence
   *        is rewound by the given number of notes. The byte following a negative number determines the number

--- a/watch-library/shared/watch/watch_tcc.h
+++ b/watch-library/shared/watch/watch_tcc.h
@@ -168,12 +168,6 @@ void watch_set_buzzer_on(void);
   */
 void watch_set_buzzer_off(void);
 
-/** @brief Returns the volume at which the buzzer should sound.
-  * @return If button sounds are turned on, then the currently configured volume. Otherwise,
-  *         MOVEMENT_DEFAULT_BUTTON_VOLUME.
-  */
-watch_buzzer_volume_t watch_buzzer_volume(void);
-
 /** @brief Plays the given note for a set duration at the currently configured volume.
   * @param note The note you wish to play, or BUZZER_NOTE_REST to disable output for the given duration.
   * @param duration_ms The duration of the note.


### PR DESCRIPTION
Currently, sounds other than the button sound (and for some watch faces, even button sounds) play at the loudest volume level, regardless of volume settings. Users may want to adjust the volume, either for volume preference or to reduce battery drain.[^1]

[^1]: The [documentation](https://www.sensorwatch.net/docs/using/settings/) also notes that "one loud beep uses five times the power of a soft beep, which will impact your battery life after a while."

Under the current design, the button sound setting is coupled with volume adjustment, via the "beep H/L/N" setting.

This PR decouples volume adjustment and makes playing the button sound more uniform across non-legacy watch faces. Specifically, it:

1. Makes `watch_buzzer_play_note` and `watch_buzzer_play_sequence` heed the current volume setting instead of playing at the loudest volume level. This lets users adjust the volume of most sounds played by watch faces.
2. Splits the "beep High/Low/None" setting into "beep Yes/No" and "volume High/Low." Some watch faces play sounds even when the button sound is turned off. This lets users retain volume control for these sounds.
3. Adds a new function, `movement_play_button_sound_if_enabled`, which plays the standard button sound, C7 for 50 ms. The PR also replaces the idiom `if (movement_button_should_sound()) watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());` with `movement_play_button_sound_if_enabled();` in non-legacy watch faces where use of this button sound is obvious. This reduces code duplication in watch faces and helps standardize the UI.
