### PR TITLE
watch-faces.mk: add totp_face.c, got lost while adding totp_lfs_face

### DIFF
--- a/watch-faces.mk
+++ b/watch-faces.mk
@@ -14,6 +14,7 @@ SRCS += \
   ./watch-faces/complication/days_since_face.c \
   ./watch-faces/complication/breathing_face.c \
   ./watch-faces/complication/squash_face.c \
+  ./watch-faces/complication/totp_face.c \
   ./watch-faces/complication/totp_lfs_face.c \
   ./watch-faces/complication/tally_face.c \
   ./watch-faces/complication/wordle_face.c \


### PR DESCRIPTION
# Issue
Building a firmware with the totp_face failed due to the missing entry in watch-faces.mk

# Solution
Add corresponding entry to watch-faces.mk