### PR TITLE
Significantly improve off axis viewing for custom LCD 

### DIFF
--- a/watch-library/hardware/watch/watch_slcd.c
+++ b/watch-library/hardware/watch/watch_slcd.c
@@ -252,7 +252,7 @@ void watch_enable_display(void) {
     slcd_clear();
 
     if (_installed_display == WATCH_LCD_TYPE_CUSTOM) {
-        slcd_set_contrast(4);
+        slcd_set_contrast(0);
     } else {
         slcd_set_contrast(9);
     }


### PR DESCRIPTION
After being frustrated not being able to read the custom LCD when viewed at a steep angle, I investigated what could be causing it to be so bad.

I eventually stumbled upon the contrast setting, and after testing a range of values 0 is the clear winner. The current value is 4.

0 greatly improves off axis viewing, for an extremely slightly reduction in actual contrast when viewed on axis.

A range of contrast values are shown in this video I made. It clearly shows both the current issue and the fix:
https://youtu.be/hoix05W9BKI?si=xAhF-QQr7Z1zbp84
