### PR TITLE
pulsometer_face: Add check for negative values

### DIFF
--- a/watch-faces/complication/pulsometer_face.c
+++ b/watch-faces/complication/pulsometer_face.c
@@ -80,6 +80,7 @@ static void pulsometer_display_measurement(pulsometer_state_t *pulsometer) {
     char buf[5];
     int16_t value = pulsometer->pulses;
 
+    if (value < 0) value = 0;
     if (value > 9999) value = 9999;
 
     snprintf(buf, sizeof(buf), "%-4hd", value);


### PR DESCRIPTION
The compiler is throwing buffer truncation warning because it's worried that pulse values could theoretically go negative (even though they shouldn't in real life).

Change: Added a simple bounds check to clamp negative pulse values to 0, silencing the compiler.