### PR TITLE
add function for playing the standard button sound

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -442,6 +442,12 @@ void movement_set_button_volume(watch_buzzer_volume_t value) {
     movement_state.settings.bit.button_volume = value;
 }
 
+void movement_play_button_sound_if_enabled(void) {
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
+    }
+}
+
 movement_clock_mode_t movement_clock_mode_24h(void) {
     return movement_state.settings.bit.clock_mode_24h ? MOVEMENT_CLOCK_MODE_24H : MOVEMENT_CLOCK_MODE_12H;
 }

--- a/movement.h
+++ b/movement.h
@@ -348,6 +348,11 @@ void movement_set_button_should_sound(bool value);
 watch_buzzer_volume_t movement_button_volume(void);
 void movement_set_button_volume(watch_buzzer_volume_t value);
 
+/** @brief Plays standard button sound, but only if beeps are turned on.
+  * @details The standard sound is BUZZER_NOTE_C7, played for 50 ms.
+  */
+void movement_play_button_sound_if_enabled(void);
+
 movement_clock_mode_t movement_clock_mode_24h(void);
 void movement_set_clock_mode_24h(movement_clock_mode_t value);
 

--- a/watch-faces/complication/alarm_face.c
+++ b/watch-faces/complication/alarm_face.c
@@ -50,11 +50,6 @@ static void _alarm_face_display_alarm_time(alarm_face_state_t *state) {
     watch_display_text(WATCH_POSITION_BOTTOM, lcdbuf);
 }
 
-static inline void button_beep() {
-    // play a beep as confirmation for a button press (if applicable)
-    if (movement_button_should_sound()) watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
-}
-
 //
 // Exported
 //
@@ -115,7 +110,7 @@ bool alarm_face_loop(movement_event_t event, void *context) {
                     state->setting_mode = ALARM_FACE_SETTING_MODE_NONE;
                     movement_request_tick_frequency(1);
                     // beep to confirm setting.
-                    button_beep();
+                    movement_play_button_sound_if_enabled();
                     // also turn the alarm on since they just set it.
                     state->alarm_is_on = 1;
                     movement_set_alarm_enabled(true);
@@ -158,7 +153,7 @@ bool alarm_face_loop(movement_event_t event, void *context) {
                 // long press in normal mode: move to hour setting mode, request fast tick.
                 state->setting_mode = ALARM_FACE_SETTING_MODE_SETTING_HOUR;
                 movement_request_tick_frequency(4);
-                button_beep();
+                movement_play_button_sound_if_enabled();
             }
             break;
         case EVENT_BACKGROUND_TASK:

--- a/watch-faces/complication/countdown_face.c
+++ b/watch-faces/complication/countdown_face.c
@@ -65,11 +65,6 @@ static inline void load_countdown(countdown_state_t *state) {
     state->seconds = state->set_seconds;
 }
 
-static inline void button_beep() {
-    // play a beep as confirmation for a button press (if applicable)
-    if (movement_button_should_sound()) watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
-}
-
 static void schedule_countdown(countdown_state_t *state) {
 
     // Calculate the new state->now_ts but don't update it until we've updated the target - 
@@ -264,7 +259,7 @@ bool countdown_face_loop(movement_event_t event, void *context) {
                     break;
                 case cd_paused:
                     reset(state);
-                    button_beep();
+                    movement_play_button_sound_if_enabled();
                     break;
                 case cd_setting:
                     state->selection++;
@@ -273,7 +268,7 @@ bool countdown_face_loop(movement_event_t event, void *context) {
                         state->mode = cd_reset;
                         store_countdown(state);
                         movement_request_tick_frequency(1);
-                        button_beep();
+                        movement_play_button_sound_if_enabled();
                     }
                     break;
             }
@@ -283,7 +278,7 @@ bool countdown_face_loop(movement_event_t event, void *context) {
             switch(state->mode) {
                 case cd_running:
                     pause(state);
-                    button_beep();
+                    movement_play_button_sound_if_enabled();
                     break;
                 case cd_reset:
                 case cd_paused:
@@ -291,7 +286,7 @@ bool countdown_face_loop(movement_event_t event, void *context) {
                     if (!(state->hours == 0 && state->minutes == 0 && state->seconds == 0)) {
                         abort_tap_detection(state);
                         start(state);
-                        button_beep();
+                        movement_play_button_sound_if_enabled();
                         watch_set_indicator(WATCH_INDICATOR_SIGNAL);
                     }
                     break;
@@ -308,7 +303,7 @@ bool countdown_face_loop(movement_event_t event, void *context) {
                     abort_tap_detection(state);
                     state->mode = cd_setting;
                     movement_request_tick_frequency(4);
-                    button_beep();
+                    movement_play_button_sound_if_enabled();
                     break;
                 case cd_setting:
                     // long press in settings mode starts quick ticks for adjusting the time
@@ -336,7 +331,7 @@ bool countdown_face_loop(movement_event_t event, void *context) {
                 }
             } else {
                 // Toggle auto-repeat
-                button_beep();
+                movement_play_button_sound_if_enabled();
                 state->repeat = !state->repeat;
                 if(state->repeat)
                     watch_set_indicator(WATCH_INDICATOR_BELL);

--- a/watch-faces/complication/fast_stopwatch_face.c
+++ b/watch-faces/complication/fast_stopwatch_face.c
@@ -119,11 +119,6 @@ void irq_handler_tc1(void) {
 
 #endif
 
-static inline void _button_beep() {
-    // play a beep as confirmation for a button press (if applicable)
-    if (movement_button_should_sound()) watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
-}
-
 /// @brief Display minutes, seconds and fractions derived from 128 Hz tick counter
 ///        on the lcd.
 /// @param ticks
@@ -280,7 +275,7 @@ bool fast_stopwatch_face_loop(movement_event_t event, void *context) {
                 movement_cancel_background_task();
             }
             _draw();
-            _button_beep();
+            movement_play_button_sound_if_enabled();
             break;
         case EVENT_LIGHT_BUTTON_DOWN:
             if (state->light_on_button) movement_illuminate_led();
@@ -302,7 +297,7 @@ bool fast_stopwatch_face_loop(movement_event_t event, void *context) {
                 } else if (_ticks) {
                     // reset stopwatch
                     _ticks = _lap_ticks = _blink_ticks = _old_minutes = _old_seconds = _hours = 0;
-                    _button_beep();
+                    movement_play_button_sound_if_enabled();
                 }
             }
             _display_ticks(_ticks);

--- a/watch-faces/complication/interval_face.c
+++ b/watch-faces/complication/interval_face.c
@@ -100,11 +100,6 @@ static uint32_t _get_now_ts() {
     return watch_utility_date_time_to_unix_time(now, 0);
 }
 
-static inline void _button_beep() {
-    // play a beep as confirmation for a button press (if applicable)
-    if (movement_button_should_sound()) watch_buzzer_play_note(BUZZER_NOTE_C7, 50);
-}
-
 static void _timer_write_info(interval_face_state_t *state, char* bottom_row, char state_str[2][4], char* index_str, uint8_t timer_page) {
     // fill display string with requested timer information
     switch (timer_page) {
@@ -536,7 +531,7 @@ bool interval_face_loop(movement_event_t event, void *context) {
         }
         break;
     case EVENT_LIGHT_LONG_PRESS:
-        _button_beep();
+        movement_play_button_sound_if_enabled();
         if (state->face_state == interval_state_setting) {
             _resume_setting(state, event.subsecond);
         } else {
@@ -561,7 +556,7 @@ bool interval_face_loop(movement_event_t event, void *context) {
             break;
         case interval_state_running:
             // pause timer
-            _button_beep();
+            movement_play_button_sound_if_enabled();
             _paused_ts = _get_now_ts();
             state->face_state = interval_state_pausing;
             movement_cancel_background_task();
@@ -569,7 +564,7 @@ bool interval_face_loop(movement_event_t event, void *context) {
             break;
         case interval_state_pausing:
             // resume paused timer
-            _button_beep();
+            movement_play_button_sound_if_enabled();
             _resume_paused_timer(state);
             _face_draw(state, event.subsecond);
             break;
@@ -586,7 +581,7 @@ bool interval_face_loop(movement_event_t event, void *context) {
         } else if (state->face_state <= interval_state_waiting) {
             if (_is_timer_empty(timer)) {
                 // jump back to timer #1
-                _button_beep();
+                movement_play_button_sound_if_enabled();
                 state->timer_idx = 0;
                 _init_timer_info(state);
             } else {
@@ -610,7 +605,7 @@ bool interval_face_loop(movement_event_t event, void *context) {
             _init_timer_info(state);
         } else if (state->face_state == interval_state_pausing) {
             // resume paused timer
-            _button_beep();
+            movement_play_button_sound_if_enabled();
             _resume_paused_timer(state);
         }
         _face_draw(state, event.subsecond);

--- a/watch-faces/complication/stopwatch_face.c
+++ b/watch-faces/complication/stopwatch_face.c
@@ -118,9 +118,7 @@ bool stopwatch_face_loop(movement_event_t event, void *context) {
             }
             break;
         case EVENT_ALARM_BUTTON_DOWN:
-            if (movement_button_should_sound()) {
-                watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
-            }
+            movement_play_button_sound_if_enabled();
             stopwatch_state->running = !stopwatch_state->running;
             if (stopwatch_state->running) {
                 // we're running now, so we need to set the start_time.

--- a/watch-faces/complication/timer_face.c
+++ b/watch-faces/complication/timer_face.c
@@ -329,7 +329,7 @@ bool timer_face_loop(movement_event_t event, void *context) {
                 case pausing:
                 case running:
                     _reset(state);
-                    if (movement_button_should_sound()) watch_buzzer_play_note(BUZZER_NOTE_C7, 50);
+                    movement_play_button_sound_if_enabled();
                     break;
                 default:
                     break;

--- a/watch-faces/sensor/lis2dw_monitor_face.c
+++ b/watch-faces/sensor/lis2dw_monitor_face.c
@@ -336,14 +336,6 @@ static void _settings_low_noise_advance(void *context)
     state->ds.low_noise = !state->ds.low_noise;
 }
 
-/* Play beep sound */
-static inline void _beep()
-{
-    if (!movement_button_should_sound())
-        return;
-    watch_buzzer_play_note(BUZZER_NOTE_C7, 50);
-}
-
 /* Print lis2dw status to console. */
 static void _lis2dw_print_state(lis2dw_device_state_t *ds)
 {
@@ -482,7 +474,7 @@ static bool _monitor_loop(movement_event_t event, void *context)
             break;
         case EVENT_LIGHT_LONG_PRESS:
             _switch_to_settings(state);
-            _beep();
+            movement_play_button_sound_if_enabled();
             break;
         default:
             movement_default_loop_handler(event);
@@ -509,7 +501,7 @@ static bool _settings_loop(movement_event_t event, void *context)
             _lis2dw_set_state(&state->ds);
             _lis2dw_print_state(&state->ds);
             _switch_to_monitor(state);
-            _beep();
+            movement_play_button_sound_if_enabled();
             break;
         case EVENT_LIGHT_BUTTON_DOWN:
             /* Do nothing. */


### PR DESCRIPTION
This PR is a commit adapted from #75. It adds the utility function `movement_play_button_sound_if_enabled` and replaces occurrences of the following pattern with it:
```c
if (movement_button_should_sound()) {
    watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
}
```