### PR TITLE
Fix for non-blinking settings in deadline_face

### DIFF
--- a/watch-faces/complication/deadline_face.c
+++ b/watch-faces/complication/deadline_face.c
@@ -490,8 +490,8 @@ static void _deadline_settings_init(deadline_state_t *state)
         _reset_deadline(state);
     }
 
-    /* Ensure 1Hz updates only */
-    _change_tick_freq(1, state);
+    /* Ensure 4Hz updates to support blinking */
+    _change_tick_freq(4, state);
 }
 
 /* Loop of setting mode */


### PR DESCRIPTION
The display of the `deadline_face` sometimes did not blink when entering settings mode. I assume this is because the blinking frequency was not set from the start. I updated the code to ensure the settings display runs at 4 Hz from the beginning.