### PR TITLE
make base32 decoding case insensitive

### DIFF
--- a/lib/base32/base32.c
+++ b/lib/base32/base32.c
@@ -79,6 +79,8 @@ static int decode_char(unsigned char c)
 {
 	int retval = -1;
 
+	if (c >= 'a' && c <= 'z')
+		retval = c - 'a';
 	if (c >= 'A' && c <= 'Z')
 		retval = c - 'A';
 	if (c >= '2' && c <= '7')


### PR DESCRIPTION
This hugely improves the experience of using the TOTP faces by supporting base32 decoding of lowercase alphabet characters too.

Both Microsoft and Fastmail provide lowercase secrets that otherwise would require you to uppercase them before adding them to `totp_uris.txt`.

Without this, the TOTP (at least the LFS variant) face just displays "No 2FA Codes" and until you strap in the console, you will not see the error "TOTP can't decode secret".