### PR TITLE
Add MOVEMENT_KEEP_LIGHT_IN_FACES option

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -656,6 +656,7 @@ void app_init(void) {
         movement_state.settings.bit.button_should_sound = MOVEMENT_DEFAULT_BUTTON_SOUND;
         movement_state.settings.bit.button_volume = MOVEMENT_DEFAULT_BUTTON_VOLUME;
         movement_state.settings.bit.to_interval = MOVEMENT_DEFAULT_TIMEOUT_INTERVAL;
+        movement_state.settings.bit.keep_lighting_on = MOVEMENT_KEEP_LIGHT_IN_FACES;
 #ifdef MOVEMENT_LOW_ENERGY_MODE_FORBIDDEN
         movement_state.settings.bit.le_interval = 0;
 #else
@@ -853,6 +854,8 @@ bool app_loop(void) {
     if (movement_state.light_ticks == 0) {
         // unless the user is holding down the LIGHT button, in which case, give them more time.
         if (HAL_GPIO_BTN_LIGHT_read()) {
+            movement_state.light_ticks = 1;
+        }else if(movement_state.settings.bit.keep_lighting_on && movement_state.current_face_idx != 0) {
             movement_state.light_ticks = 1;
         } else {
             movement_force_led_off();

--- a/movement.h
+++ b/movement.h
@@ -85,6 +85,8 @@ typedef union {
         bool use_imperial_units : 1;        // indicates whether to use metric units (the default) or imperial.
         
         bool button_volume : 1;             // 0 for soft beep, 1 for loud beep. If button_should_sound (above) is false, this is ignored.
+
+        bool keep_lighting_on : 1;          //boolean to keep lighting on in other faces
     } bit;
     uint32_t reg;
 } movement_settings_t;

--- a/movement_config.h
+++ b/movement_config.h
@@ -64,6 +64,11 @@ const watch_face_t watch_faces[] = {
 /* Set to true for 24h mode or false for 12h mode */
 #define MOVEMENT_DEFAULT_24H_MODE false
 
+/* Set to true to keep the lighting on while scrolling
+ * trough watch faces other than the first one
+ */
+#define MOVEMENT_KEEP_LIGHT_IN_FACES false
+
 /* Enable or disable the sound on mode button press */
 #define MOVEMENT_DEFAULT_BUTTON_SOUND true
 


### PR DESCRIPTION
Add a new option in movement.h to keep the LED light on while scrolling trough the watch faces.

I wasn't sure where I should place the keep_lighting_on toggle so I moved it to movement_settings_t for now

Let me know if anything needs to be changed / added to be merged.