### PR TITLE
Add tap support in the simulator

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -714,6 +714,7 @@ void app_setup(void) {
                 break;
             }
         }
+        watch_register_interrupt_callback(HAL_GPIO_A3_pin(), cb_accelerometer_event, INTERRUPT_TRIGGER_RISING);
 #endif
 
         // set up the 1 minute alarm (for background tasks and low power updates)

--- a/watch-library/shared/driver/lis2dw.c
+++ b/watch-library/shared/driver/lis2dw.c
@@ -25,6 +25,10 @@
 #include "lis2dw.h"
 #include "watch.h"
 
+#if __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 bool lis2dw_begin(void) {
 #ifdef I2C_SERCOM
     if (lis2dw_get_device_id() != LIS2DW_WHO_AM_I_VAL) {
@@ -421,7 +425,13 @@ lis2dw_wakeup_source_t lis2dw_get_wakeup_source() {
 
 lis2dw_interrupt_source_t lis2dw_get_interrupt_source(void) {
 #ifdef I2C_SERCOM
+    #if __EMSCRIPTEN__
+        return (lis2dw_interrupt_source_t) EM_ASM_INT({
+            return window.LIS2DW_INTERRUPT_SRC || 0; // Fallback to 0 if not defined
+        });
+    #else
     return (lis2dw_interrupt_source_t) watch_i2c_read8(LIS2DW_ADDRESS, LIS2DW_REG_ALL_INT_SRC);
+    #endif
 #else
     return 0;
 #endif


### PR DESCRIPTION
Here we are expanding `watch_extint` with another "button". Even if its not really a button.

I did some choices which may or may not be the best way

- Avoided doing the highlight styling we do on the buttons. Probably doesn't make much sense in the tap context
- Added listeners to 2 elements. My testing showed that this made it easier to use, since depending on where on the screen you click, you might get an event on `#light` or `#displays`
- Wrote the value to JS, and made emscripten fetch the value from there. This is technically less correct than the way the buttons are implemented I guess
- Added the actual interrupt callback. This was just added in a somewhat random place that works for emscripten