### PR TITLE
Battery logging and current temp display

### DIFF
--- a/watch-faces/sensor/temperature_logging_face.c
+++ b/watch-faces/sensor/temperature_logging_face.c
@@ -27,10 +27,36 @@
 #include "temperature_logging_face.h"
 #include "watch.h"
 
+#define THERMISTOR_LOGGING_CYC (TEMPERATURE_LOGGING_NUM_DATA_POINTS + 1)
+
 static bool skip = false;
 
+static void _temperature_display_face_update_display(bool in_fahrenheit) {
+    float temperature_c = movement_get_temperature();
+    if (in_fahrenheit) {
+        watch_display_float_with_best_effort(temperature_c * 1.8 + 32.0, "#F");
+    } else {
+        watch_display_float_with_best_effort(temperature_c, "#C");
+    }
+}
+
+static void _temperature_logging_face_blink_display(bool in_fahrenheit, bool update_now) {
+    watch_date_time_t date_time = movement_get_local_date_time();
+    if (date_time.unit.second % 5 == 0 || update_now) {
+        _temperature_display_face_update_display(in_fahrenheit);
+        watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+    }
+    else if (date_time.unit.second % 5 == 4) {
+        // Not 100% on this, but I like the idea of using the signal indicator to indicate that we're sensing data.
+        // In this case we turn the indicator on a second before the reading is taken, and clear it when we're done.
+        // In reality the measurement takes a fraction of a second, but this is just to show something is happening.
+        watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+        return;
+    }
+}
+
 static void _temperature_logging_face_log_data(temperature_logging_state_t *logger_state) {
-    watch_date_time_t date_time = watch_rtc_get_date_time();
+    watch_date_time_t date_time = movement_get_local_date_time();
     size_t pos = logger_state->data_points % TEMPERATURE_LOGGING_NUM_DATA_POINTS;
 
     logger_state->data[pos].timestamp.reg = date_time.reg;
@@ -38,7 +64,7 @@ static void _temperature_logging_face_log_data(temperature_logging_state_t *logg
     logger_state->data_points++;
 }
 
-static void _temperature_logging_face_update_display(temperature_logging_state_t *logger_state, bool in_fahrenheit, bool clock_mode_24h) {
+static void _temperature_logging_face_update_display(temperature_logging_state_t *logger_state, bool in_fahrenheit, bool clock_mode_24h, bool from_btn) {
     int8_t pos = (logger_state->data_points - 1 - logger_state->display_index) % TEMPERATURE_LOGGING_NUM_DATA_POINTS;
     char buf[7];
 
@@ -46,9 +72,17 @@ static void _temperature_logging_face_update_display(temperature_logging_state_t
     watch_clear_indicator(WATCH_INDICATOR_PM);
     watch_clear_colon();
 
+    if (logger_state->display_index == TEMPERATURE_LOGGING_NUM_DATA_POINTS){
+        _temperature_logging_face_blink_display(in_fahrenheit, from_btn);
+        watch_display_text_with_fallback(WATCH_POSITION_TOP, "TEMP ", "TE  ");
+        return;
+    }
+    watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+
     if (pos < 0) {
         // no data at this index
         watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "LOG", "TL");
+        watch_clear_decimal_if_available();
         watch_display_text(WATCH_POSITION_BOTTOM, "no dat");
         sprintf(buf, "%2d", logger_state->display_index);
         watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
@@ -85,7 +119,7 @@ void temperature_logging_face_setup(uint8_t watch_face_index, void ** context_pt
     (void) watch_face_index;
 
     // if temperature is invalid, we don't have a temperature sensor which means we shouldn't be here.
-    if (movement_get_temperature() == 0xFFFFFFFF) skip = true;
+    if (movement_get_temperature() == (float)0xFFFFFFFF) skip = true;
 
     if (*context_ptr == NULL) {
         *context_ptr = malloc(sizeof(temperature_logging_state_t));
@@ -95,12 +129,13 @@ void temperature_logging_face_setup(uint8_t watch_face_index, void ** context_pt
 
 void temperature_logging_face_activate(void *context) {
     temperature_logging_state_t *logger_state = (temperature_logging_state_t *)context;
-    logger_state->display_index = 0;
+    logger_state->display_index = TEMPERATURE_LOGGING_NUM_DATA_POINTS;
     logger_state->ts_ticks = 0;
 }
 
 bool temperature_logging_face_loop(movement_event_t event, void *context) {
     temperature_logging_state_t *logger_state = (temperature_logging_state_t *)context;
+    bool displaying_curr_temp = logger_state->display_index == TEMPERATURE_LOGGING_NUM_DATA_POINTS;
     switch (event.event_type) {
         case EVENT_TIMEOUT:
             movement_move_to_face(0);
@@ -110,23 +145,40 @@ bool temperature_logging_face_loop(movement_event_t event, void *context) {
             movement_illuminate_led();
             break;
         case EVENT_LIGHT_BUTTON_DOWN:
-            logger_state->ts_ticks = 2;
-            _temperature_logging_face_update_display(logger_state, movement_use_imperial_units(), movement_clock_mode_24h());
             break;
-        case EVENT_ALARM_BUTTON_DOWN:
-            logger_state->display_index = (logger_state->display_index + 1) % TEMPERATURE_LOGGING_NUM_DATA_POINTS;
+        case EVENT_LIGHT_BUTTON_UP:
+            logger_state->display_index = (logger_state->display_index + THERMISTOR_LOGGING_CYC - 1) % THERMISTOR_LOGGING_CYC;
             logger_state->ts_ticks = 0;
-            // fall through
+            _temperature_logging_face_update_display(logger_state, movement_use_imperial_units(), movement_clock_mode_24h(), true);
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            logger_state->display_index = (logger_state->display_index + 1) % THERMISTOR_LOGGING_CYC;
+            logger_state->ts_ticks = 0;
+            _temperature_logging_face_update_display(logger_state, movement_use_imperial_units(), movement_clock_mode_24h(), true);
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            if (displaying_curr_temp) movement_set_use_imperial_units(!movement_use_imperial_units());
+            else logger_state->ts_ticks = 2;
+            _temperature_logging_face_update_display(logger_state, movement_use_imperial_units(), movement_clock_mode_24h(), true);
+            break;
         case EVENT_ACTIVATE:
             if (skip) {
                 movement_move_to_next_face();
                 return false;
             }
-            _temperature_logging_face_update_display(logger_state, movement_use_imperial_units(), movement_clock_mode_24h());
+            _temperature_logging_face_update_display(logger_state, movement_use_imperial_units(), movement_clock_mode_24h(), true);
             break;
         case EVENT_TICK:
-            if (logger_state->ts_ticks && --logger_state->ts_ticks == 0) {
-                _temperature_logging_face_update_display(logger_state, movement_use_imperial_units(), movement_clock_mode_24h());
+            if(displaying_curr_temp) _temperature_display_face_update_display(movement_use_imperial_units());
+            else if (logger_state->ts_ticks && --logger_state->ts_ticks == 0) {
+                _temperature_logging_face_update_display(logger_state, movement_use_imperial_units(), movement_clock_mode_24h(), false);
+            }
+            break;
+        case EVENT_LOW_ENERGY_UPDATE:
+            // update every 5 minutes
+            if (displaying_curr_temp && movement_get_local_date_time().unit.minute % 5 == 0) {
+                watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+                _temperature_logging_face_update_display(logger_state, movement_use_imperial_units(), movement_clock_mode_24h(), true);
             }
             break;
         case EVENT_BACKGROUND_TASK:
@@ -150,7 +202,7 @@ movement_watch_face_advisory_t temperature_logging_face_advise(void *context) {
 
     // this will get called at the top of each minute, so all we check is if we're at the top of the hour as well.
     // if we are, we ask for a background task.
-    retval.wants_background_task = watch_rtc_get_date_time().unit.minute == 0;
+    retval.wants_background_task = movement_get_local_date_time().unit.minute == 0;
 
     return retval;
 }

--- a/watch-faces/sensor/temperature_logging_face.h
+++ b/watch-faces/sensor/temperature_logging_face.h
@@ -27,14 +27,21 @@
 #include "pins.h"
 
 /*
- * THERMISTOR LOGGING (aka Temperature Log)
+ * TEMPERATURE LOGGING (aka Temperature Log)
  *
  * This watch face automatically logs the temperature once an hour, and
  * maintains a 36-hour log of readings. This watch face is admittedly rather
  * complex, and bears some explanation.
  *
- * The main display shows the letters “TL” in the top left, indicating the
- * name of the watch face. At the top right, it displays the index of the
+ * The face shows the current temperature readings, and refreshes every 5 seconds.
+ * When showing the current temperature, it'll display TE (or TEMP on the custom display).
+ * 
+ * You can scroll through past temeprature readings by using the "Alarm" button to go to
+ * a previous reading. The top left will now display TL (or LOG on the custom display).
+ * At the top right, it displays the index of the reading; 0 represents the most recent
+ * reading taken, 1 represents one hour earlier, etc. The bottom line in this mode displays
+ * the logged temperature.
+ *
  * reading; 0 represents the most recent reading taken, 1 represents one
  * hour earlier, etc. The bottom line in this mode displays the logged
  * temperature.
@@ -43,7 +50,11 @@
  * you will see the number at the top right advance from 0 to 1 to 2, all
  * the way to 35, the oldest reading available.
  *
- * A short press of the “Light” button will briefly display the timestamp
+ * A short press of the "Light" button advances to the next newest reading.
+ * Whena t the current reading, it'll advance to the oldest one.
+ *
+ * A long press of the “Alarm” button will change the watch's units from C to F if you're
+ * looking at the current temperature. Otherwise, it will briefly display the timestamp
  * of the reading. The letters at the top left will display the word “At”,
  * and the main line will display the timestamp of the currently displayed
  * data point. The number in the top right will display the day of the month

--- a/watch-faces/sensor/voltage_face.c
+++ b/watch-faces/sensor/voltage_face.c
@@ -27,6 +27,8 @@
 #include "voltage_face.h"
 #include "watch.h"
 
+#define VOLTAGE_LOGGING_CYC (VOLTAGE_NUM_DATA_POINTS + 1)
+
 static void _voltage_face_update_display(void) {
     float voltage = (float)watch_get_vcc_voltage() / 1000.0;
 
@@ -34,30 +36,122 @@ static void _voltage_face_update_display(void) {
     watch_display_float_with_best_effort(voltage, " V");
 }
 
+static void _voltage_face_blink_display(bool update_now) {
+    watch_date_time_t date_time = movement_get_local_date_time();
+    if (date_time.unit.second % 5 == 0 || update_now) {
+        _voltage_face_update_display();
+        watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+    }
+    else if (date_time.unit.second % 5 == 4) {
+        watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+        return;
+    }
+}
+
+static void _voltage_face_log_data(voltage_face_state_t *logger_state) {
+    watch_date_time_t date_time = movement_get_local_date_time();
+    size_t pos = logger_state->data_points % VOLTAGE_NUM_DATA_POINTS;
+
+    logger_state->data[pos].timestamp.reg = date_time.reg;
+    float voltage = (float)watch_get_vcc_voltage() / 1000.0;
+    logger_state->data[pos].voltage = voltage;
+    logger_state->data_points++;
+}
+
+static void _voltage_face_logging_update_display(voltage_face_state_t *logger_state, bool clock_mode_24h, bool from_btn) {
+    int8_t pos = (logger_state->data_points - 1 - logger_state->display_index) % VOLTAGE_NUM_DATA_POINTS;
+    char buf[7];
+
+    watch_clear_indicator(WATCH_INDICATOR_24H);
+    watch_clear_indicator(WATCH_INDICATOR_PM);
+    watch_clear_colon();
+
+    if (logger_state->display_index == VOLTAGE_NUM_DATA_POINTS){
+        _voltage_face_blink_display(from_btn);
+        watch_display_text_with_fallback(WATCH_POSITION_TOP, "BAT  ", "BA  ");
+        return;
+    }
+    watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+
+    if (pos < 0) {
+        // no data at this index
+        watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "BAT", "BA");
+        watch_clear_decimal_if_available();
+        watch_display_text(WATCH_POSITION_BOTTOM, "no dat");
+        sprintf(buf, "%2d", logger_state->display_index);
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+    } else if (logger_state->ts_ticks) {
+        // we are displaying the timestamp in response to a button press
+        watch_date_time_t date_time = logger_state->data[pos].timestamp;
+        watch_set_colon();
+        if (clock_mode_24h) {
+            watch_set_indicator(WATCH_INDICATOR_24H);
+        } else {
+            if (date_time.unit.hour > 11) watch_set_indicator(WATCH_INDICATOR_PM);
+            date_time.unit.hour %= 12;
+            if (date_time.unit.hour == 0) date_time.unit.hour = 12;
+        }
+        watch_display_text(WATCH_POSITION_TOP_LEFT, "AT");
+        sprintf(buf, "%2d", date_time.unit.day);
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+        sprintf(buf, "%2d%02d%02d", date_time.unit.hour, date_time.unit.minute, date_time.unit.second);
+        watch_display_text(WATCH_POSITION_BOTTOM, buf);
+    } else {
+        // we are displaying the voltage
+        watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "BAT", "BA");
+        sprintf(buf, "%2d", logger_state->display_index);
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+        watch_display_float_with_best_effort(logger_state->data[pos].voltage, " V");
+    }
+}
+
 void voltage_face_setup(uint8_t watch_face_index, void ** context_ptr) {
     (void) watch_face_index;
-    (void) context_ptr;
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(voltage_face_state_t));
+        memset(*context_ptr, 0, sizeof(voltage_face_state_t));
+    }
 }
 
 void voltage_face_activate(void *context) {
-    (void) context;
+    voltage_face_state_t *logger_state = (voltage_face_state_t *)context;
+    logger_state->display_index = VOLTAGE_NUM_DATA_POINTS;
+    logger_state->ts_ticks = 0;
 }
 
 bool voltage_face_loop(movement_event_t event, void *context) {
-    (void) context;
-    watch_date_time_t date_time;
+    voltage_face_state_t *logger_state = (voltage_face_state_t *)context;
+    bool displaying_curr_volt = logger_state->display_index == VOLTAGE_NUM_DATA_POINTS;
     switch (event.event_type) {
+        case EVENT_LIGHT_LONG_PRESS:
+            // light button shows the timestamp, but if you need the light, long press it.
+            movement_illuminate_led();
+            break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            logger_state->display_index = (logger_state->display_index + VOLTAGE_LOGGING_CYC - 1) % VOLTAGE_LOGGING_CYC;
+            logger_state->ts_ticks = 0;
+            _voltage_face_logging_update_display(logger_state, movement_clock_mode_24h(), true);
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            logger_state->display_index = (logger_state->display_index + 1) % VOLTAGE_LOGGING_CYC;
+            logger_state->ts_ticks = 0;
+            _voltage_face_logging_update_display(logger_state, movement_clock_mode_24h(), true);
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            if (displaying_curr_volt) break;
+            else logger_state->ts_ticks = 2;
+            _voltage_face_logging_update_display(logger_state, movement_clock_mode_24h(), true);
+            break;
         case EVENT_ACTIVATE:
             if (watch_sleep_animation_is_running()) watch_stop_sleep_animation();
-            _voltage_face_update_display();
+            _voltage_face_logging_update_display(logger_state, movement_clock_mode_24h(), true);
             break;
         case EVENT_TICK:
-            date_time = movement_get_local_date_time();
-            if (date_time.unit.second % 5 == 4) {
-                watch_set_indicator(WATCH_INDICATOR_SIGNAL);
-            } else if (date_time.unit.second % 5 == 0) {
-                _voltage_face_update_display();
-                watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+            if(displaying_curr_volt) _voltage_face_update_display();
+            else if (logger_state->ts_ticks && --logger_state->ts_ticks == 0) {
+                _voltage_face_logging_update_display(logger_state, movement_clock_mode_24h(), false);
             }
             break;
         case EVENT_LOW_ENERGY_UPDATE:
@@ -67,11 +161,14 @@ bool voltage_face_loop(movement_event_t event, void *context) {
                 watch_start_sleep_animation(1000);
             }
             // update once an hour
-            if (date_time.unit.minute == 0) {
+            if (date_time.unit.minute == 0 && displaying_curr_volt) {
                 watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
                 _voltage_face_update_display();
                 watch_display_text_with_fallback(WATCH_POSITION_SECONDS, " V", "  ");
             }
+            break;
+        case EVENT_BACKGROUND_TASK:
+            _voltage_face_log_data(logger_state);
             break;
         default:
             movement_default_loop_handler(event);
@@ -83,4 +180,15 @@ bool voltage_face_loop(movement_event_t event, void *context) {
 
 void voltage_face_resign(void *context) {
     (void) context;
+}
+
+movement_watch_face_advisory_t voltage_face_advise(void *context) {
+    (void) context;
+    movement_watch_face_advisory_t retval = { 0 };
+
+    // this will get called at the top of each minute, so all we check is if we're at the top of the hour as well.
+    // if we are, we ask for a background task.
+    retval.wants_background_task = movement_get_local_date_time().unit.minute == 0;
+
+    return retval;
 }

--- a/watch-faces/sensor/voltage_face.h
+++ b/watch-faces/sensor/voltage_face.h
@@ -36,6 +36,28 @@
  * Note that the Simple Clock watch face includes a low battery warning, so you
  * don’t technically need to this watch face unless you want to track the
  * battery level.
+ *
+ * You can scroll through past voltage readings by using the "Alarm" button to go to
+ * a previous reading. At the top right, it displays the index of the reading;
+ * 0 represents the most recent reading taken, 1 represents one hour earlier, etc.
+ * The bottom line in this mode displays the logged voltage.
+ *
+ * A short press of the “Alarm” button advances to the next oldest reading;
+ * you will see the number at the top right advance from 0 to 1 to 2, all
+ * the way to 35, the oldest reading available.
+ *
+ * A short press of the "Light" button advances to the next newest reading.
+ * Whena t the current reading, it'll advance to the oldest one.
+ *
+ * A long press of the “Alarm” button will briefly display the timestamp
+ * of the reading. The letters at the top left will display the word “At”,
+ * and the main line will display the timestamp of the currently displayed
+ * data point. The number in the top right will display the day of the month
+ * for the given data point; for example, you can read “At 22 3:00 PM” as
+ * ”At 3:00 PM on the 22nd”.
+ *
+ * If you need to illuminate the LED to read the data point, long press the
+ * Light button and release it.
  */
 
 #include "movement.h"

--- a/watch-faces/sensor/voltage_face.h
+++ b/watch-faces/sensor/voltage_face.h
@@ -25,6 +25,8 @@
 #ifndef VOLTAGE_FACE_H_
 #define VOLTAGE_FACE_H_
 
+#define VOLTAGE_NUM_DATA_POINTS (36)
+
 /*
  * VOLTAGE face
  *
@@ -38,17 +40,30 @@
 
 #include "movement.h"
 
+typedef struct {
+    watch_date_time_t timestamp;
+    float voltage;
+} voltage_face_data_point_t;
+
+typedef struct {
+    uint8_t display_index;  // the index we are displaying on screen
+    uint8_t ts_ticks;       // when the user taps the LIGHT button, we show the timestamp for a few ticks.
+    int32_t data_points;    // the absolute number of data points logged
+    voltage_face_data_point_t data[VOLTAGE_NUM_DATA_POINTS];
+} voltage_face_state_t;
+
 void voltage_face_setup(uint8_t watch_face_index, void ** context_ptr);
 void voltage_face_activate(void *context);
 bool voltage_face_loop(movement_event_t event, void *context);
 void voltage_face_resign(void *context);
+movement_watch_face_advisory_t voltage_face_advise(void *context);
 
 #define voltage_face ((const watch_face_t){ \
     voltage_face_setup, \
     voltage_face_activate, \
     voltage_face_loop, \
     voltage_face_resign, \
-    NULL, \
+    voltage_face_advise, \
 })
 
 #endif // VOLTAGE_FACE_H_


### PR DESCRIPTION
This PR merges the Temperature display face into the Temperature logging face.
It also gives the Voltage face the same type of logging capability, where 36 hours of voltages can be saved.

One bug found in the simulator is that when the background update function gets called in sleep mode, the display goes blank. It's been tested to be the same in the main repo, so this is a quirk, not a new bug.