### PR TITLE
Added default temp of 25C in simulator

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -587,6 +587,9 @@ bool movement_set_accelerometer_motion_threshold(uint8_t new_threshold) {
 }
 
 float movement_get_temperature(void) {
+#if __EMSCRIPTEN__
+    return 25;
+#endif
     float temperature_c = (float)0xFFFFFFFF;
 
     if (movement_state.has_thermistor) {


### PR DESCRIPTION
If we're using the simulator, have the temperature be read as 25C so faces like the temperature logging face won't be skipped over.