### PR TITLE
Added watch_disable_display

### DIFF
--- a/watch-library/hardware/watch/watch_slcd.c
+++ b/watch-library/hardware/watch/watch_slcd.c
@@ -260,6 +260,10 @@ void watch_enable_display(void) {
     slcd_enable();
 }
 
+void watch_disable_display(void) {
+    slcd_disable();
+}
+
 inline void watch_set_pixel(uint8_t com, uint8_t seg) {
     slcd_set_segment(com, seg);
 }

--- a/watch-library/shared/watch/watch_slcd.h
+++ b/watch-library/shared/watch/watch_slcd.h
@@ -98,6 +98,10 @@ typedef enum {
   */
 void watch_enable_display(void);
 
+/** @brief Disables the Segment LCD display.
+  */
+void watch_disable_display(void);
+
 /** @brief Sets a pixel. Use this to manually set a pixel with a given common and segment number.
   *        See <a href="segmap.html">segmap.html</a>.
   * @param com the common pin, numbered from 0-2.

--- a/watch-library/simulator/watch/watch_slcd.c
+++ b/watch-library/simulator/watch/watch_slcd.c
@@ -50,15 +50,21 @@ void watch_enable_display(void) {
     _watch_update_indicator_segments();
 #endif
 
-    EM_ASM({
 #if defined(FORCE_CUSTOM_LCD_TYPE)
-        document.getElementById("classic").style.display = "none";
+    EM_ASM({document.getElementById("custom").style.display = "";});
+    EM_ASM({document.getElementById("classic").style.display = "none";});
 #else
-        document.getElementById("custom").style.display = "none";
+    EM_ASM({document.getElementById("custom").style.display = "none";});
+    EM_ASM({document.getElementById("classic").style.display = "";});
 #endif
-    });
 
     watch_clear_display();
+}
+
+void watch_disable_display(void) {
+    watch_clear_display();
+    EM_ASM({document.getElementById("classic").style.display = "none";});
+    EM_ASM({document.getElementById("custom").style.display = "none";});
 }
 
 void watch_set_pixel(uint8_t com, uint8_t seg) {


### PR DESCRIPTION
The code states to disable the slcd when not in use, but that's not possible with the current code.
This addition allows the LCD to be disabled more easily.

Tested in the simulator and hardware.
Power profiling shows ~1.7uA in power savings.


```  * @details The segment LCD controller consumes about 3 microamperes of power with no segments on, and
  *          about 4 microamperes with all segments on. There is also a slight power impact associated
  *          with updating the screen (about 1 microampere to update at 1 Hz). For the absolute lowest
  *          power operation, update the display only when its contents have changed, and disable the
  *          SLCD peripheral when the screen is not in use.
```

### Power Profile
Sleep Mode | Sleep Mode With Display Turned Off
:-------------------------:|:-------------------------:
<img width="1660" height="790" alt="sleep" src="https://github.com/user-attachments/assets/973616da-62c1-498d-b464-e1d00a7eaf62" />| <img width="1660" height="790" alt="deepsleep" src="https://github.com/user-attachments/assets/9d60232d-4a64-444a-8449-4682255ebe67" />



