### PR TITLE
Allow to pass secrets to totp_face through a separate (ignored) header.

### DIFF
--- a/watch-faces/complication/.gitignore
+++ b/watch-faces/complication/.gitignore
@@ -1,0 +1,1 @@
+totp_face.secrets.h

--- a/watch-faces/complication/totp_face.c
+++ b/watch-faces/complication/totp_face.c
@@ -64,10 +64,14 @@ typedef struct {
 ////////////////////////////////////////////////////////////////////////////////
 // Enter your TOTP key data below
 
+#if __has_include("totp_face.secrets.h")
+#include "totp_face.secrets.h"
+#else
 static totp_t credentials[] = {
     CREDENTIAL(2F, "JBSWY3DPEHPK3PXP", SHA1, 30),
     CREDENTIAL(AC, "JBSWY3DPEHPK3PXP", SHA1, 30),
 };
+#endif
 
 // END OF KEY DATA.
 ////////////////////////////////////////////////////////////////////////////////

--- a/watch-faces/complication/totp_face.h
+++ b/watch-faces/complication/totp_face.h
@@ -61,6 +61,10 @@
  *      o `algorithm` is one of the supported hashing algorithms listed above.
  *      o `timestep` is how often the TOTP refreshes in seconds. This is usually
  *        30 seconds.
+ *  o Alternatively, place the `credentials` variable as-is in a file named
+ *    `totp_face.secrets.h` in this directory, and it will be included instead.
+ *    This lowers the risk of commiting your OTP secrets to GitHub as that file
+ *    is listed in the .gitignore file.
  *
  * If you have more than one secret key, press ALARM to cycle through them.
  * Press LIGHT to cycle in the other direction or keep it pressed longer to


### PR DESCRIPTION
That header (`totp_face.secrets.h`) is listed in the .gitignore file for that directory, so that there is limited risk to commit it to GitHub by mistake (compared to storing the secrets directly in `totp_face.c`). And this is also easier to use than totp_lfs_face (until secrets can be sent to that face over IR).