### PR TITLE
Allow to use 3 character long labels in the totp face.

### DIFF
--- a/watch-faces/complication/totp_face.c
+++ b/watch-faces/complication/totp_face.c
@@ -45,7 +45,7 @@
 #endif
 
 typedef struct {
-    unsigned char labels[2];
+    const char* labels;
     hmac_alg algorithm;
     uint32_t period;
     size_t encoded_key_length;
@@ -66,7 +66,7 @@ typedef struct {
 
 static totp_t credentials[] = {
     CREDENTIAL(2F, "JBSWY3DPEHPK3PXP", SHA1, 30),
-    CREDENTIAL(AC, "JBSWY3DPEHPK3PXP", SHA1, 30),
+    CREDENTIAL(AAC, "JBSWY3DPEHPK3PXP", SHA1, 30),
 };
 
 // END OF KEY DATA.
@@ -121,15 +121,14 @@ static void totp_generate(totp_state_t *totp_state) {
 }
 
 static void totp_display_error(totp_state_t *totp_state) {
-    char buf[10 + 1];
     totp_t *totp = totp_current(totp_state);
-
-    snprintf(buf, sizeof(buf), "%c%c  ERROR ", totp->labels[0], totp->labels[1]);
-    watch_display_text(0, buf);
+    watch_clear_display();
+    watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, totp->labels, totp->labels);
+    watch_display_text(WATCH_POSITION_BOTTOM, "ERROR");
 }
 
 static void totp_display_code(totp_state_t *totp_state) {
-    char buf[14];
+    char buf[7];
     div_t result;
     uint8_t valid_for;
     totp_t *totp = totp_current(totp_state);
@@ -140,9 +139,15 @@ static void totp_display_code(totp_state_t *totp_state) {
         totp_state->steps = result.quot;
     }
     valid_for = totp->period - result.rem;
-    sprintf(buf, "%c%c%2d%06lu", totp->labels[0], totp->labels[1], valid_for, totp_state->current_code);
 
-    watch_display_text(0, buf);
+    watch_clear_display();
+    watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, totp->labels, totp->labels);
+
+    sprintf(buf, "%2d", valid_for);
+    watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+
+    sprintf(buf, "%06u", totp_state->current_code);
+    watch_display_text(WATCH_POSITION_BOTTOM, buf);
 }
 
 static void totp_display(totp_state_t *totp_state) {

--- a/watch-faces/complication/totp_face.h
+++ b/watch-faces/complication/totp_face.h
@@ -55,8 +55,9 @@
  *    TOTP credentials. The file includes two examples that you can use as a
  *    reference. Credentials are added with the `CREDENTIAL` macro in the form
  *    `CREDENTIAL(label, key, algorithm, timestep)` where:
- *      o `label` is a 2 character label that is displayed in the weekday digits
- *        to identify the TOTP credential.
+ *      o `label` is a 2 or 3 character label that is displayed in the weekday
+ *        digits to identify the TOTP credential (only the first 2 characters
+ *        are displayed on the classic LCD).
  *      o `key` is a string with the base32 encoded secret.
  *      o `algorithm` is one of the supported hashing algorithms listed above.
  *      o `timestep` is how often the TOTP refreshes in seconds. This is usually


### PR DESCRIPTION
As the title says. Use the more recent Second Movement display methods to support 2 or 3 character labels or the OTPs.