### PR TITLE
Set time face isn't blank at the beginning of displaying it

### DIFF
--- a/watch-faces/settings/set_time_face.c
+++ b/watch-faces/settings/set_time_face.c
@@ -91,6 +91,8 @@ bool set_time_face_loop(movement_event_t event, void *context) {
     watch_date_time_t date_time = movement_get_local_date_time();
 
     switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            break;
         case EVENT_TICK:
             if (_quick_ticks_running) {
                 if (HAL_GPIO_BTN_ALARM_read()) _handle_alarm_button(date_time, current_page);


### PR DESCRIPTION
The set-time face shows blank when you go to it; longer than other faces.
This is because we draw the face after our event loop. Since EVENT_ACTIVATE isn't a case, we'll go to the default loop and return true before we get to draw.

Adding `case EVENT_ACTIVATE: break;` will stop the default loop from running and immediately show the time, which reduces perceived lag on the watch.