### PR TITLE
Feat: Gregorian Calendar watch face

### DIFF
--- a/movement_faces.h
+++ b/movement_faces.h
@@ -73,4 +73,5 @@
 #include "wareki_face.h"
 #include "deadline_face.h"
 #include "wordle_face.h"
+#include "calendar_face.h"
 // New includes go above this line.

--- a/watch-faces.mk
+++ b/watch-faces.mk
@@ -48,4 +48,5 @@ SRCS += \
   ./watch-faces/sensor/lis2dw_monitor_face.c \
   ./watch-faces/complication/wareki_face.c \
   ./watch-faces/complication/deadline_face.c \
+  ./watch-faces/complication/calendar_face.c \
 # New watch faces go above this line.

--- a/watch-faces/complication/calendar_face.c
+++ b/watch-faces/complication/calendar_face.c
@@ -1,0 +1,311 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Moritz Glöckl
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "calendar_face.h"
+#include "watch_utility.h"
+#include "calendar_face_holidays.h"
+
+// Example: Fill with holidays for Austria and pan-European holidays
+// Checkout calendar_face_holidays.h for more holidays and examples
+static const uint16_t holidays[] = {
+    HOLIDAY_NEW_YEARS_DAY,            // Jan 1
+    HOLIDAY_AT_EPIPHANY,              // Jan 6
+    HOLIDAY_GOOD_FRIDAY,              // Dynamic (Easter - 2)
+    HOLIDAY_EASTER_SUNDAY,            // Dynamic (Easter)
+    HOLIDAY_EASTER_MONDAY,            // Dynamic (Easter + 1)
+    HOLIDAY_AT_ASSUMPTION_DAY,        // Aug 15
+    HOLIDAY_MAY_DAY,                  // May 1
+    HOLIDAY_ASCENSION_DAY,            // Dynamic (Easter + 39)
+    HOLIDAY_PENTECOST_MONDAY,         // Dynamic (Easter + 50)
+    HOLIDAY_CORPUS_CHRISTI,           // Dynamic (Easter + 60)
+    HOLIDAY_AT_NATIONAL_DAY,          // Oct 26
+    HOLIDAY_AT_IMMACULATE_CONCEPTION, // Dec 8
+    HOLIDAY_CHRISTMAS_DAY,            // Dec 25
+    HOLIDAY_BOXING_DAY                // Dec 26
+};
+#define HOLIDAY_COUNT (sizeof(holidays) / sizeof(holidays[0]))
+
+static void reset_state(calendar_state_t *state)
+{
+    state->scrolling_mode = 0;
+    state->blink_state = 0;
+    state->scroll_tick_count = 0;
+}
+static inline uint8_t days_in_month(uint8_t m, uint8_t y)
+{
+    static const uint8_t month_days[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    uint16_t year = y + 2020;
+    if (m == 2)
+    {
+        bool leap = ((year & 3) == 0) && ((year % 100 != 0) || (year % 400 == 0));
+        return 28 + leap;
+    }
+    return month_days[m - 1];
+}
+
+static void display_calendar(uint8_t m, uint8_t d, uint8_t y, bool show_holiday)
+{
+    static const char months[12][4] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+    static const char weekdays[7][3] = {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"};
+    watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, months[m - 1], months[m - 1]);
+    char year_buf[4];
+    year_buf[0] = '0' + ((y + 20) / 10);
+    year_buf[1] = '0' + ((y + 20) % 10);
+    year_buf[2] = '\0';
+    watch_display_text(WATCH_POSITION_TOP_RIGHT, year_buf);
+    char main_buf[8];
+    uint8_t wd = watch_utility_get_iso8601_weekday_number(y + 2020, m, d);
+    main_buf[0] = (d < 10) ? ' ' : '0' + (d / 10);
+    main_buf[1] = '0' + (d % 10);
+    main_buf[2] = '-';
+    main_buf[3] = weekdays[(wd == 7) ? 0 : wd][0];
+    main_buf[4] = weekdays[(wd == 7) ? 0 : wd][1];
+    main_buf[5] = '\0';
+    watch_display_text(WATCH_POSITION_BOTTOM, main_buf);
+    if (show_holiday)
+        watch_set_indicator(WATCH_INDICATOR_BELL);
+    else
+        watch_clear_indicator(WATCH_INDICATOR_BELL);
+}
+
+static void scroll_day_forward(calendar_state_t *s)
+{
+    s->scroll_day++;
+    if (s->scroll_day > days_in_month(s->scroll_month, s->scroll_year))
+    {
+        s->scroll_day = 1;
+        s->scroll_month++;
+        if (s->scroll_month > 12)
+        {
+            s->scroll_month = 1;
+            s->scroll_year = (s->scroll_year + 1) % 100; // wrap year at 100
+        }
+    }
+}
+static void scroll_day_backward(calendar_state_t *s)
+{
+    if (s->scroll_day > 1)
+    {
+        s->scroll_day--;
+    }
+    else
+    {
+        s->scroll_month--;
+        if (s->scroll_month < 1)
+        {
+            s->scroll_month = 12;
+            s->scroll_year = (s->scroll_year == 0) ? 99 : s->scroll_year - 1;
+        }
+        s->scroll_day = days_in_month(s->scroll_month, s->scroll_year);
+    }
+}
+static void scroll_month_forward(calendar_state_t *s)
+{
+    s->scroll_month++;
+    if (s->scroll_month > 12)
+    {
+        s->scroll_month = 1;
+        s->scroll_year = (s->scroll_year + 1) % 100; // wrap year at 100
+    }
+}
+static void scroll_month_backward(calendar_state_t *s)
+{
+    if (s->scroll_month > 1)
+    {
+        s->scroll_month--;
+    }
+    else
+    {
+        s->scroll_month = 12;
+        s->scroll_year = (s->scroll_year == 0) ? 99 : s->scroll_year - 1;
+    }
+}
+static void scroll_year_forward(calendar_state_t *s) { s->scroll_year = (s->scroll_year + 1) % 100; /* % 100, but faster */ }
+static void scroll_year_backward(calendar_state_t *s) { s->scroll_year = (s->scroll_year == 0) ? 99 : s->scroll_year - 1; }
+
+static void (*scroll_forward[3])(calendar_state_t *) = {scroll_day_forward, scroll_month_forward, scroll_year_forward};
+static void (*scroll_backward[3])(calendar_state_t *) = {scroll_day_backward, scroll_month_backward, scroll_year_backward};
+
+void calendar_face_setup(uint8_t watch_face_index, void **context_ptr)
+{
+    (void)watch_face_index;
+    if (*context_ptr == NULL)
+    {
+        *context_ptr = calloc(1, sizeof(calendar_state_t));
+    }
+}
+
+void calendar_face_activate(void *context)
+{
+    calendar_state_t *state = (calendar_state_t *)context;
+    movement_request_tick_frequency(4);
+    reset_state(state);
+}
+
+bool calendar_face_loop(movement_event_t event, void *context)
+{
+    calendar_state_t *state = (calendar_state_t *)context;
+    static const char *months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+    static const char *weekdays[] = {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"};
+    switch (event.event_type)
+    {
+    case EVENT_MODE_BUTTON_UP:
+        if ((state->scrolling_mode))
+            state->scroll_mode = (state->scroll_mode + 1) % 3;
+        else
+            return movement_default_loop_handler(event);
+        break;
+    case EVENT_MODE_LONG_PRESS:
+        if ((state->scrolling_mode))
+        {
+            reset_state(state);
+        }
+        else
+        {
+            movement_move_to_face(0);
+        }
+        break;
+    case EVENT_ACTIVATE:
+        watch_clear_display();
+        reset_state(state);
+        break;
+    case EVENT_TICK:
+    {
+        watch_date_time_t now = watch_rtc_get_date_time();
+        uint8_t m, d, y;
+        bool show_holiday;
+        if (!(state->scrolling_mode))
+        {
+            m = now.unit.month;
+            d = now.unit.day;
+            y = now.unit.year;
+            show_holiday = is_public_holiday(m, d, y + 2020, holidays, HOLIDAY_COUNT);
+            display_calendar(m, d, y, show_holiday);
+            movement_request_tick_frequency(1);
+        }
+        else
+        {
+            m = state->scroll_month;
+            d = state->scroll_day;
+            y = state->scroll_year;
+            state->blink_state = !(state->blink_state);
+            bool blink = state->blink_state;
+            bool show_month = !(state->scroll_mode == 1 && !blink);
+            bool show_year = !(state->scroll_mode == 2 && !blink);
+            bool show_day = !(state->scroll_mode == 0 && !blink);
+
+            show_holiday = is_public_holiday(m, d, y + 2020, holidays, HOLIDAY_COUNT);
+            if (show_month && show_year && show_day)
+                display_calendar(m, d, y, show_holiday);
+            else
+            {
+                if (!show_month)
+                    watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "   ", "   ");
+                else
+                    watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, months[m - 1], months[m - 1]);
+                if (!show_year)
+                    watch_display_text(WATCH_POSITION_TOP_RIGHT, "  ");
+                else
+                {
+                    char year_buf[4];
+                    snprintf(year_buf, sizeof(year_buf), "%02d", (y + 20));
+                    watch_display_text(WATCH_POSITION_TOP_RIGHT, year_buf);
+                }
+                if (!show_day)
+                    watch_display_text(WATCH_POSITION_BOTTOM, "     ");
+                else
+                {
+                    char main_buf[8];
+                    uint8_t wd = watch_utility_get_iso8601_weekday_number(y + 2020, m, d);
+                    snprintf(main_buf, sizeof(main_buf), "%2d-%s", d, weekdays[(wd == 7) ? 0 : wd]);
+                    watch_display_text(WATCH_POSITION_BOTTOM, main_buf);
+                }
+                if (show_holiday)
+                    watch_set_indicator(WATCH_INDICATOR_BELL);
+                else
+                    watch_clear_indicator(WATCH_INDICATOR_BELL);
+            }
+
+            movement_request_tick_frequency(4);
+        }
+        break;
+    }
+    case EVENT_LIGHT_BUTTON_UP:
+        watch_set_led_off();
+        scroll_backward[state->scroll_mode](state);
+        break;
+    case EVENT_LIGHT_LONG_PRESS:
+        watch_set_led_off();
+        for (int i = 0, n = (state->scroll_mode == 0) ? 7 : 3; i < n; i++)
+            scroll_backward[state->scroll_mode](state);
+        break;
+    case EVENT_ALARM_BUTTON_UP:
+        scroll_forward[state->scroll_mode](state);
+        break;
+    case EVENT_ALARM_LONG_PRESS:
+        if (!state->scrolling_mode)
+        {
+            watch_date_time_t now = watch_rtc_get_date_time();
+            state->scrolling_mode = true;
+            state->scroll_day = now.unit.day;
+            state->scroll_month = now.unit.month;
+            state->scroll_year = now.unit.year;
+            state->blink_state = true;
+            state->scroll_tick_count = 0;
+            state->scroll_mode = 0;
+        }
+        else
+        {
+            for (int i = 0, n = (state->scroll_mode == 0) ? 7 : 3; i < n; i++)
+                scroll_forward[state->scroll_mode](state);
+        }
+        break;
+    case EVENT_TIMEOUT:
+        reset_state(state);
+        movement_move_to_face(0);
+        break;
+    case EVENT_LOW_ENERGY_UPDATE:
+    {
+        watch_date_time_t now = watch_rtc_get_date_time();
+        uint8_t m = now.unit.month;
+        uint8_t d = now.unit.day;
+        uint8_t y = now.unit.year;
+        bool show_holiday = is_public_holiday(m, d, y + 2020, holidays, HOLIDAY_COUNT);
+        display_calendar(m, d, y, show_holiday);
+        break;
+    }
+    default:
+        return movement_default_loop_handler(event);
+    }
+    return true;
+}
+
+void calendar_face_resign(void *context)
+{
+    calendar_state_t *state = (calendar_state_t *)context;
+    if (state->scrolling_mode)
+        reset_state(state);
+}

--- a/watch-faces/complication/calendar_face.h
+++ b/watch-faces/complication/calendar_face.h
@@ -1,0 +1,82 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Moritz Glöckl
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "movement.h"
+
+/*
+ * European Calendar Watch Face
+ *
+ * This watch face displays the current date, weekday, and highlights public holidays for the selected country.
+ *
+ * Setup:
+ *   - Holidays are configured in `calendar_face.c` via the `holidays[]` array.
+ *     To change the country or add/remove holidays, edit the array and use macros from `calendar_face_holidays.h`.
+ *     Both fixed-date and dynamic (Easter-based) holidays are supported.
+ *
+ * Usage:
+ *   - By default, the watch face shows today's date and highlights if it is a holiday.
+ *   - Hold ALARM to enter scrolling mode (shows today as starting point).
+ *   - Press ALARM to scroll forward (day/month/year depending on mode).
+ *   - Press LIGHT to scroll backward.
+ *   - Hold ALARM or LIGHT for fast scrolling (7 days or 3 months/years).
+ *   - Press MODE to switch between day, month, and year scrolling modes.
+ *   - Hold MODE to exit scrolling mode and return to the default view.
+ *   - Timeout or long MODE press returns to the first watch face.
+ *   - The bell indicator shows when the selected date is a public holiday.
+ *
+ * To customize holidays, use the macros in `calendar_face_holidays.h` and update the `holidays[]` array in `calendar_face.c`.
+ */
+
+typedef enum {
+    CAL_SCROLL_DAY,
+    CAL_SCROLL_MONTH,
+    CAL_SCROLL_YEAR
+} cal_scroll_mode_t;
+
+typedef struct {
+    bool scrolling_mode;
+    bool blink_state;
+    uint8_t scroll_day;
+    uint8_t scroll_month;
+    uint8_t scroll_year;
+    uint16_t scroll_tick_count;
+    cal_scroll_mode_t scroll_mode;
+} calendar_state_t;
+
+
+void calendar_face_setup(uint8_t watch_face_index, void ** context_ptr);
+void calendar_face_activate(void *context);
+bool calendar_face_loop(movement_event_t event, void *context);
+void calendar_face_resign(void *context);
+
+
+#define calendar_face ((const watch_face_t){ \
+    calendar_face_setup, \
+    calendar_face_activate, \
+    calendar_face_loop, \
+    calendar_face_resign, \
+    NULL, \
+})

--- a/watch-faces/complication/calendar_face_holidays.h
+++ b/watch-faces/complication/calendar_face_holidays.h
@@ -1,0 +1,151 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Moritz Glöckl
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef CALENDAR_FACE_HOLIDAYS_H
+#define CALENDAR_FACE_HOLIDAYS_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// --- Pan-European Fixed-Date Holidays ---
+#define HOLIDAY_NEW_YEARS_DAY 101  // January 1
+#define HOLIDAY_MAY_DAY 501        // May 1 (Labour Day)
+#define HOLIDAY_CHRISTMAS_DAY 1225 // December 25
+#define HOLIDAY_BOXING_DAY 1226    // December 26
+
+// --- Austria (AT) ---
+#define HOLIDAY_AT_NATIONAL_DAY 1026          // October 26
+#define HOLIDAY_AT_ASSUMPTION_DAY 815         // August 15
+#define HOLIDAY_AT_IMMACULATE_CONCEPTION 1208 // December 8
+#define HOLIDAY_AT_EPIPHANY 106               // January 6
+
+// --- Germany (DE) ---
+#define HOLIDAY_DE_UNITY_DAY 1003       // October 3
+#define HOLIDAY_DE_REFORMATION_DAY 1031 // October 31
+#define HOLIDAY_DE_ASSUMPTION_DAY 815   // August 15
+#define HOLIDAY_DE_EPIPHANY 106         // January 6
+
+// --- United Kingdom (UK) ---
+#define HOLIDAY_UK_NEW_YEARS_DAY 101  // January 1
+#define HOLIDAY_UK_MAY_DAY 501        // May 1
+#define HOLIDAY_UK_CHRISTMAS_DAY 1225 // December 25
+#define HOLIDAY_UK_BOXING_DAY 1226    // December 26
+
+// --- France (FR) ---
+#define HOLIDAY_FR_BASTILLE_DAY 714   // July 14
+#define HOLIDAY_FR_ARMISTICE_DAY 1111 // November 11
+#define HOLIDAY_FR_ASSUMPTION_DAY 815 // August 15
+#define HOLIDAY_FR_EPIPHANY 106       // January 6
+
+// --- Italy (IT) ---
+#define HOLIDAY_IT_REPUBLIC_DAY 602           // June 2
+#define HOLIDAY_IT_ASSUMPTION_DAY 815         // August 15
+#define HOLIDAY_IT_EPIPHANY 106               // January 6
+#define HOLIDAY_IT_IMMACULATE_CONCEPTION 1208 // December 8
+
+// --- Spain (ES) ---
+#define HOLIDAY_ES_NATIONAL_DAY 1012          // October 12
+#define HOLIDAY_ES_ASSUMPTION_DAY 815         // August 15
+#define HOLIDAY_ES_EPIPHANY 106               // January 6
+#define HOLIDAY_ES_IMMACULATE_CONCEPTION 1208 // December 8
+
+// --- Dynamic Holidays ---
+#define HOLIDAY_EASTER_SUNDAY 0                               // Base: Easter
+#define HOLIDAY_EASTER_MONDAY (HOLIDAY_EASTER_SUNDAY + 1)     // Easter Monday
+#define HOLIDAY_GOOD_FRIDAY (HOLIDAY_EASTER_SUNDAY - 2)       // Good Friday
+#define HOLIDAY_ASCENSION_DAY (HOLIDAY_EASTER_SUNDAY + 39)    // Ascension Day
+#define HOLIDAY_PENTECOST_SUNDAY (HOLIDAY_EASTER_SUNDAY + 49) // Pentecost Sunday
+#define HOLIDAY_PENTECOST_MONDAY (HOLIDAY_EASTER_SUNDAY + 50) // Pentecost Monday
+#define HOLIDAY_CORPUS_CHRISTI (HOLIDAY_EASTER_SUNDAY + 60)   // Corpus Christi
+
+static inline void calculate_easter_date(uint16_t year, uint8_t *month, uint8_t *day)
+{
+    // Meeus/Jones/Butcher algorithm
+    uint16_t a = year % 19;
+    uint16_t b = year / 100;
+    uint16_t c = year - b * 100; // year % 100
+    uint16_t d = b >> 2;         // b / 4
+    uint16_t e = b & 3;          // b % 4
+    uint16_t f = (b + 8) / 25;
+    uint16_t g = (b - f + 1) / 3;
+    uint16_t h = (19 * a + b - d - g + 15);
+    h = h - ((h / 30) * 30);     // h % 30
+    uint16_t i = c >> 2;         // c / 4
+    uint16_t k = c & 3;          // c % 4
+    uint16_t l = (32 + (e << 1) + (i << 1) - h - k);
+    l = l - ((l / 7) * 7);       // l % 7
+    uint16_t m = (a + 11 * h + 22 * l) / 451;
+    uint16_t temp = h + l - 7 * m + 114;
+    uint16_t month_calc = temp / 31;
+    uint16_t day_calc = (temp - month_calc * 31) + 1;
+    *month = (uint8_t)month_calc;
+    *day = (uint8_t)day_calc;
+}
+
+static inline void calculate_dynamic_holiday(uint16_t year, int offset_days, uint8_t *month, uint8_t *day)
+{
+    uint8_t easter_month, easter_day;
+    calculate_easter_date(year, &easter_month, &easter_day);
+
+    bool leap = (year & 3) == 0 && ((year % 100 != 0) || (year % 400 == 0));
+    static const uint8_t month_days[12] = {31,28,31,30,31,30,31,31,30,31,30,31};
+    uint16_t easter_doy = easter_day;
+    for (uint8_t m = 1; m < easter_month; m++)
+        easter_doy += (m == 2) ? (28 + leap) : month_days[m - 1];
+    uint16_t holiday_doy = easter_doy + offset_days;
+    uint8_t m = 1;
+    while (holiday_doy > 0)
+    {
+        uint8_t dim = (m == 2) ? (28 + leap) : month_days[m - 1];
+        if (holiday_doy <= dim) break;
+        holiday_doy -= dim;
+        m++;
+    }
+    *month = m;
+    *day = (uint8_t)holiday_doy;
+}
+
+static inline bool is_public_holiday(uint8_t month, uint8_t day, uint16_t year, const uint16_t *holidays, size_t holiday_count)
+{
+    uint16_t md = month * 100 + day;
+    for (size_t i = 0; i < holiday_count; i++)
+    {
+        // Dynamic holidays: offsets from Easter (-60 to +60)
+        if ((int16_t)holidays[i] >= -60 && (int16_t)holidays[i] <= 60)
+        {
+            uint8_t dyn_month, dyn_day;
+            calculate_dynamic_holiday(year, (int16_t)holidays[i], &dyn_month, &dyn_day);
+            if (month == dyn_month && day == dyn_day)
+                return true;
+        }
+        else if (holidays[i] > 0)
+        {
+            if (holidays[i] == md)
+                return true;
+        }
+    }
+    return false;
+}
+
+#endif // CALENDAR_FACE_HOLIDAYS_H


### PR DESCRIPTION
New Gregorian Calendar face. Supports scrolling back & forth and holidays.

European/Gregorian Calendar Watch Face

This watch face displays the current date, weekday, and highlights public holidays for the selected country.

Setup:
- Holidays are configured in calendar_face.c via the holidays[] array.
To change the country or add/remove holidays, edit the array and use macros from calendar_face_holidays.h.
Both fixed-date and dynamic (Easter-based) holidays are supported.

Usage:
- By default, the watch face shows today's date and highlights if it is a holiday.
- Hold ALARM to enter scrolling mode (shows today as starting point).
- Press ALARM to scroll forward (day/month/year depending on mode).
- Press LIGHT to scroll backward.
- Hold ALARM or LIGHT for fast scrolling (7 days or 3 months/years).
- Press MODE to switch between day, month, and year scrolling modes.
- Hold MODE to exit scrolling mode and return to the default view.
- Timeout or long MODE press returns to the first watch face.
- The bell indicator shows when the selected date is a public holiday.

To customize holidays, use the macros in calendar_face_holidays.h and update the holidays[] array in calendar_face.c.