### PR TITLE
Add emoticon to logging face

### DIFF
--- a/watch-faces/sensor/activity_logging_face.c
+++ b/watch-faces/sensor/activity_logging_face.c
@@ -29,6 +29,16 @@
 #include "watch.h"
 #include "watch_utility.h"
 
+static char _activity_logging_get_mood_face(uint16_t active_minutes) {
+    if (active_minutes >= 150) {
+        return ')';  // happy: 150+ minutes
+    } else if (active_minutes >= 30) {
+        return '|';  // neutral: 30-149 minutes
+    } else {
+        return '(';  // sad: 0-29 minutes
+    }
+}
+
 static void _activity_logging_face_update_display(activity_logging_state_t *state) {
     char buf[8];
     watch_date_time_t timestamp = movement_get_local_date_time();
@@ -39,8 +49,16 @@ static void _activity_logging_face_update_display(activity_logging_state_t *stat
         // if we are at today, just show the count so far
         snprintf(buf, 8, "%2d", timestamp.unit.day);
         watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
-        snprintf(buf, 8, "%4d  ", state->active_minutes_today);
-        watch_display_text(WATCH_POSITION_BOTTOM, buf);
+
+        if (state->show_emoticon) {
+            char mood_face = _activity_logging_get_mood_face(state->active_minutes_today);
+            snprintf(buf, 8, ": %c    ", mood_face);
+            watch_display_text(WATCH_POSITION_BOTTOM, buf);
+            watch_set_colon();
+        } else {
+            snprintf(buf, 8, "%4d  ", state->active_minutes_today);
+            watch_display_text(WATCH_POSITION_BOTTOM, buf);
+        }
 
         // also indicate that this is the active day — we are still sensing active minutes!
         watch_set_indicator(WATCH_INDICATOR_SIGNAL);
@@ -81,6 +99,8 @@ void activity_logging_face_setup(uint8_t watch_face_index, void ** context_ptr) 
 void activity_logging_face_activate(void *context) {
     activity_logging_state_t *state = (activity_logging_state_t *)context;
     state->display_index = 0;
+    state->show_emoticon = true;
+    state->emoticon_tick_count = 0;
 }
 
 bool activity_logging_face_loop(movement_event_t event, void *context) {
@@ -99,6 +119,16 @@ bool activity_logging_face_loop(movement_event_t event, void *context) {
             {
                 if (movement_get_local_date_time().unit.second == 0 && state->display_index == 0) {
                     _activity_logging_face_update_display(state);
+                }
+
+                // Handle emoticon display timing using tick counter
+                if (state->show_emoticon) {
+                    state->emoticon_tick_count++;
+                    if (state->emoticon_tick_count >= 1) {
+                        state->show_emoticon = false;
+                        watch_clear_colon();
+                        _activity_logging_face_update_display(state);
+                    }
                 }
             }
             break;

--- a/watch-faces/sensor/activity_logging_face.h
+++ b/watch-faces/sensor/activity_logging_face.h
@@ -54,6 +54,8 @@ typedef struct {
     uint8_t display_index;                              // the index we are displaying on screen
     uint16_t active_minutes_today;                      // the number of active minutes logged today
     bool previous_minute_was_active;                    // we only want to count two or more consecutive active minutes
+    bool show_emoticon;                                 // whether to show emoticon instead of count
+    uint8_t emoticon_tick_count;                        // tick counter for emoticon display (1 second = 1 tick)
 } activity_logging_state_t;
 
 void activity_logging_face_setup(uint8_t watch_face_index, void ** context_ptr);


### PR DESCRIPTION
This PR presents an emoticon using the colon and 6th digit, in activity logging face on activate event, for 1 sec. 

The emoticon is decided based on [this values](https://www.who.int/news-room/fact-sheets/detail/physical-activity#:~:text=Levels%20of%20physical%20inactivity%20globally), 

- Happy: 150+ minutes
- Neutral: 30-149 minutes
- Sad: 0-29 minutes

This might depend on how activity threshold is set. Works for me at ~0.22g, but might need a way to set them up in runtime?