### PR TITLE
I2c returns result

### DIFF
--- a/watch-library/hardware/watch/watch_i2c.c
+++ b/watch-library/hardware/watch/watch_i2c.c
@@ -23,6 +23,7 @@
  */
 
 #include "watch_i2c.h"
+#include "i2c.h"
 
 #ifdef I2C_SERCOM
 
@@ -37,29 +38,29 @@ void watch_disable_i2c(void) {
     i2c_disable();
 }
 
-i2c_result_t watch_i2c_send(int16_t addr, uint8_t *buf, uint16_t length) {
-    return i2c_write(addr, buf, length);
+int8_t watch_i2c_send(int16_t addr, uint8_t *buf, uint16_t length) {
+    return (int8_t)i2c_write(addr, buf, length);
 }
 
-i2c_result_t watch_i2c_receive(int16_t addr, uint8_t *buf, uint16_t length) {
-    return i2c_read(addr, buf, length);
+int8_t watch_i2c_receive(int16_t addr, uint8_t *buf, uint16_t length) {
+    return (int8_t)i2c_read(addr, buf, length);
 }
 
-i2c_result_t watch_i2c_write8(int16_t addr, uint8_t reg, uint8_t data) {
+int8_t watch_i2c_write8(int16_t addr, uint8_t reg, uint8_t data) {
     uint8_t buf[2];
     buf[0] = reg;
     buf[1] = data;
 
-    return watch_i2c_send(addr, (uint8_t *)&buf, 2);
+    return (int8_t)watch_i2c_send(addr, (uint8_t *)&buf, 2);
 }
 
 uint8_t watch_i2c_read8(int16_t addr, uint8_t reg) {
     uint8_t data;
 
-    if (watch_i2c_send(addr, (uint8_t *)&reg, 1) != I2C_RESULT_SUCCESS) {
+    if (watch_i2c_send(addr, (uint8_t *)&reg, 1) != 0) {
         return 0;
     }
-    if (watch_i2c_receive(addr, (uint8_t *)&data, 1) != I2C_RESULT_SUCCESS) {
+    if (watch_i2c_receive(addr, (uint8_t *)&data, 1) != 0) {
         return 0;
     }
 
@@ -69,10 +70,10 @@ uint8_t watch_i2c_read8(int16_t addr, uint8_t reg) {
 uint16_t watch_i2c_read16(int16_t addr, uint8_t reg) {
     uint16_t data;
 
-    if (watch_i2c_send(addr, (uint8_t *)&reg, 1) != I2C_RESULT_SUCCESS) {
+    if (watch_i2c_send(addr, (uint8_t *)&reg, 1) != 0) {
         return 0;
     }
-    if (watch_i2c_receive(addr, (uint8_t *)&data, 2) != I2C_RESULT_SUCCESS) {
+    if (watch_i2c_receive(addr, (uint8_t *)&data, 2) != 0) {
         return 0;
     }
     return data;
@@ -82,10 +83,10 @@ uint32_t watch_i2c_read24(int16_t addr, uint8_t reg) {
     uint32_t data;
     data = 0;
 
-    if (watch_i2c_send(addr, (uint8_t *)&reg, 1) != I2C_RESULT_SUCCESS) {
+    if (watch_i2c_send(addr, (uint8_t *)&reg, 1) != 0) {
         return 0;
     }
-    if (watch_i2c_receive(addr, (uint8_t *)&data, 3) != I2C_RESULT_SUCCESS) {
+    if (watch_i2c_receive(addr, (uint8_t *)&data, 3) != 0) {
         return 0;
     }
     return data << 8;
@@ -94,10 +95,10 @@ uint32_t watch_i2c_read24(int16_t addr, uint8_t reg) {
 uint32_t watch_i2c_read32(int16_t addr, uint8_t reg) {
     uint32_t data;
 
-    if (watch_i2c_send(addr, (uint8_t *)&reg, 1) != I2C_RESULT_SUCCESS) {
+    if (watch_i2c_send(addr, (uint8_t *)&reg, 1) != 0) {
         return 0;
     }
-    if (watch_i2c_receive(addr, (uint8_t *)&data, 4) != I2C_RESULT_SUCCESS) {
+    if (watch_i2c_receive(addr, (uint8_t *)&data, 4) != 0) {
         return 0;
     }
     return data;

--- a/watch-library/shared/watch/watch_i2c.h
+++ b/watch-library/shared/watch/watch_i2c.h
@@ -26,7 +26,6 @@
 ////< @file watch_i2c.h
 
 #include "watch.h"
-#include "i2c.h"
 
 /** @addtogroup i2c I2C Controller Driver
   * @brief This section covers functions related to the SAM L22's built-I2C driver, including
@@ -48,7 +47,7 @@ void watch_disable_i2c(void);
   * @param length The number of bytes in buf that you wish to send.
   * @return 0 if no error code, otherwise a code via i2c_result_t
   */
-i2c_result_t watch_i2c_send(int16_t addr, uint8_t *buf, uint16_t length);
+int8_t watch_i2c_send(int16_t addr, uint8_t *buf, uint16_t length);
 
 /** @brief Receives a series of values from a device on the I2C bus.
   * @param addr The address of the device you wish to hear from.
@@ -56,7 +55,7 @@ i2c_result_t watch_i2c_send(int16_t addr, uint8_t *buf, uint16_t length);
   * @param length The number of bytes that you wish to receive.
   * @return 0 if no error code, otherwise a code via i2c_result_t
   */
-i2c_result_t watch_i2c_receive(int16_t addr, uint8_t *buf, uint16_t length);
+int8_t watch_i2c_receive(int16_t addr, uint8_t *buf, uint16_t length);
 
 /** @brief Writes a byte to a register in an I2C device.
   * @param addr The address of the device you wish to address.
@@ -64,7 +63,7 @@ i2c_result_t watch_i2c_receive(int16_t addr, uint8_t *buf, uint16_t length);
   * @param data The value that you wish to set the register to.
   * @return 0 if no error code, otherwise a code via i2c_result_t
   */
-i2c_result_t watch_i2c_write8(int16_t addr, uint8_t reg, uint8_t data);
+int8_t watch_i2c_write8(int16_t addr, uint8_t reg, uint8_t data);
 
 /** @brief Reads a byte from a register in an I2C device.
   * @param addr The address of the device you wish to address.

--- a/watch-library/simulator/watch/watch_i2c.c
+++ b/watch-library/simulator/watch/watch_i2c.c
@@ -28,16 +28,16 @@ void watch_enable_i2c(void) {}
 
 void watch_disable_i2c(void) {}
 
-i2c_result_t watch_i2c_send(int16_t addr, uint8_t *buf, uint16_t length) {
-    return I2C_RESULT_SUCCESS;
+int8_t watch_i2c_send(int16_t addr, uint8_t *buf, uint16_t length) {
+    return 0;
 }
 
-i2c_result_t watch_i2c_receive(int16_t addr, uint8_t *buf, uint16_t length) {
-    return I2C_RESULT_SUCCESS;
+int8_t watch_i2c_receive(int16_t addr, uint8_t *buf, uint16_t length) {
+    return 0;
 }
 
-i2c_result_t watch_i2c_write8(int16_t addr, uint8_t reg, uint8_t data) {
-    return I2C_RESULT_SUCCESS;
+int8_t watch_i2c_write8(int16_t addr, uint8_t reg, uint8_t data) {
+    return 0;
 }
 
 uint8_t watch_i2c_read8(int16_t addr, uint8_t reg) {


### PR DESCRIPTION
This commits has the HAL for I2C return the I2C error so logic that uses I2C can respond in case an I2C failure occurs.