### PR TITLE
Always show timestamp in console in simulator

### DIFF
--- a/watch-library/simulator/shell.html
+++ b/watch-library/simulator/shell.html
@@ -1575,7 +1575,7 @@
       if (outputElement) outputElement.value = ''; // clear browser cache
       return function(text) {
         if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
-        console.log(text);
+        console.log(Date.now(), text);
         if (outputElement) {
           outputElement.value += text + "\n";
           outputElement.scrollTop = outputElement.scrollHeight; // focus on bottom


### PR DESCRIPTION
To me its always been helpful to show timings in the console, since from time to time you are wondering about if the timing is off.

This can help debug a range of issues, but one example would be wrt sound. So for example to more accurately know when the print statement was done, and then analyze afterwards if the timing was off