### PR TITLE
Run all available tests in lib folders automatically

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,56 @@
+name: Run Unit Tests
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - gh-pages
+
+jobs:
+  discover-tests:
+    runs-on: ubuntu-latest
+    outputs:
+      test_dirs: ${{ steps.find-tests.outputs.test_dirs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Find test directories
+        id: find-tests
+        run: |
+          echo "Auto-discovering test directories with Makefiles"
+          # Find all directories named 'test' that contain a Makefile inside lib
+          DIRS=$(find lib -type d -name "test" -exec test -f "{}/Makefile" \; -print | tr '\n' ',' | sed 's/,$//')
+
+          # Convert to JSON array for matrix
+          if [ -n "$DIRS" ]; then
+            JSON_ARRAY="[$(echo $DIRS | sed 's/,/","/g' | sed 's/^/"/;s/$/"/')]"
+          else
+            JSON_ARRAY="[]"
+          fi
+
+          echo "test_dirs=$JSON_ARRAY" >> $GITHUB_OUTPUT
+          echo "Found test directories: $JSON_ARRAY"
+
+  run-tests:
+    needs: discover-tests
+    if: needs.discover-tests.outputs.test_dirs != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test_dir: ${{ fromJson(needs.discover-tests.outputs.test_dirs) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run tests in ${{ matrix.test_dir }}
+        run: |
+          echo "Running tests in: ${{ matrix.test_dir }}"
+          if [ ! -f "Makefile" ]; then
+            echo "Error: No Makefile found in ${{ matrix.test_dir }}"
+            exit 1
+          fi
+          make test
+        working-directory: ${{ matrix.test_dir }}

--- a/lib/chirpy_tx/test/.gitignore
+++ b/lib/chirpy_tx/test/.gitignore
@@ -1,0 +1,3 @@
+# Build artifacts
+*.o
+test_chirpy

--- a/lib/chirpy_tx/test/Makefile
+++ b/lib/chirpy_tx/test/Makefile
@@ -1,0 +1,46 @@
+# Makefile for chirpy_tx tests
+
+CC = gcc
+CFLAGS = -Wall -Wextra -std=c11 -I.. -I.
+LDFLAGS =
+
+# Directories
+SRC_DIR = ..
+TEST_DIR = .
+
+# Source files
+CHIRPY_SRC = $(SRC_DIR)/chirpy_tx.c
+UNITY_SRC = unity.c
+TEST_SRC = test_main.c
+
+# Object files
+CHIRPY_OBJ = chirpy_tx.o
+UNITY_OBJ = unity.o
+TEST_OBJ = test_main.o
+
+# Output binary
+TEST_BIN = test_chirpy
+
+.PHONY: all clean test run
+
+all: $(TEST_BIN)
+
+$(TEST_BIN): $(CHIRPY_OBJ) $(UNITY_OBJ) $(TEST_OBJ)
+	$(CC) $(LDFLAGS) -o $@ $^
+
+$(CHIRPY_OBJ): $(CHIRPY_SRC)
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+$(UNITY_OBJ): $(UNITY_SRC)
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+$(TEST_OBJ): $(TEST_SRC)
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+test: $(TEST_BIN)
+	./$(TEST_BIN)
+
+run: test
+
+clean:
+	rm -f $(CHIRPY_OBJ) $(UNITY_OBJ) $(TEST_OBJ) $(TEST_BIN)

--- a/lib/chirpy_tx/test/test_main.c
+++ b/lib/chirpy_tx/test/test_main.c
@@ -25,7 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
-#include "../src/lib/chirpy_tx.h"
+#include "../chirpy_tx.h"
 #include "unity.h"
 
 


### PR DESCRIPTION
We actually have tests in the lib folder (chirpy) that are currently not being run on PRs and integrated into the CI pipelines.

As I am about to also do a pull request within the lib folder, and intending to include tests, I would love it if all tests were automatically run in here. Simply discovered and run by itself.

So the current implementation here finds all paths named "test" within lib, and find the ones that have a Makefile. Here we then assume you can run `make test`.

This was not the case with chirpy, but I added a Makefile and tweaked the include path slightly. And now it runs in github actions automatically :tada: 

Link to succesfull run of the chirpy tests (for convenience): https://github.com/joeycastillo/second-movement/actions/runs/18940194968/job/54076814867?pr=136