### PR TITLE
Added packed attribute to movement settings struct.

### DIFF
--- a/movement.h
+++ b/movement.h
@@ -63,29 +63,31 @@ typedef struct {
     uint8_t blue : 4;
 } movement_color_t;
 
+struct _settings {
+    uint8_t version : 2;                // A version number for the struct. 0-3; let's try not to update too often.
+    bool button_should_sound : 1;       // if true, pressing a button emits a sound.
+    uint8_t to_interval : 2;            // an inactivity interval for asking the active face to resign.
+    uint8_t le_interval : 3;            // 0 to disable low energy mode, or an inactivity interval for going into low energy mode.
+    uint8_t led_duration : 3;           // how many seconds to shine the LED for (x2), 0 to shine only while the button is depressed, or all bits set to disable the LED altogether.
+    uint8_t led_red_color : 4;          // for general purpose illumination, the red LED value (0-15)
+    uint8_t led_green_color : 4;        // for general purpose illumination, the green LED value (0-15)
+    uint8_t led_blue_color : 4;         // for general purpose illumination, the green LED value (0-15)
+    uint8_t time_zone : 6;              // an integer representing an index in the time zone table.
+
+    // while Movement itself doesn't implement a clock or display units, it may make sense to include some
+    // global settings for watch faces to check. The 12/24 hour preference could inform a clock or a
+    // time-oriented complication like a sunrise/sunset timer, and a simple locale preference could tell an
+    // altimeter to display feet or meters as easily as it tells a thermometer to display degrees in F or C.
+    bool clock_mode_24h : 1;            // indicates whether clock should use 12 or 24 hour mode.
+    bool use_imperial_units : 1;        // indicates whether to use metric units (the default) or imperial.
+
+    bool button_volume : 1;             // 0 for soft beep, 1 for loud beep. If button_should_sound (above) is false, this is ignored.
+} __attribute__((packed));
+
 // movement_settings_t contains global settings that cover watch behavior, including preferences around clock and unit
 // display, time zones, buzzer behavior, LED color and low energy mode timeouts.
 typedef union {
-    struct {
-        uint8_t version : 2;                // A version number for the struct. 0-3; let's try not to update too often.
-        bool button_should_sound : 1;       // if true, pressing a button emits a sound.
-        uint8_t to_interval : 2;            // an inactivity interval for asking the active face to resign.
-        uint8_t le_interval : 3;            // 0 to disable low energy mode, or an inactivity interval for going into low energy mode.
-        uint8_t led_duration : 3;           // how many seconds to shine the LED for (x2), 0 to shine only while the button is depressed, or all bits set to disable the LED altogether.
-        uint8_t led_red_color : 4;          // for general purpose illumination, the red LED value (0-15)
-        uint8_t led_green_color : 4;        // for general purpose illumination, the green LED value (0-15)
-        uint8_t led_blue_color : 4;         // for general purpose illumination, the green LED value (0-15)
-        uint8_t time_zone : 6;              // an integer representing an index in the time zone table.
-
-        // while Movement itself doesn't implement a clock or display units, it may make sense to include some
-        // global settings for watch faces to check. The 12/24 hour preference could inform a clock or a
-        // time-oriented complication like a sunrise/sunset timer, and a simple locale preference could tell an
-        // altimeter to display feet or meters as easily as it tells a thermometer to display degrees in F or C.
-        bool clock_mode_24h : 1;            // indicates whether clock should use 12 or 24 hour mode.
-        bool use_imperial_units : 1;        // indicates whether to use metric units (the default) or imperial.
-        
-        bool button_volume : 1;             // 0 for soft beep, 1 for loud beep. If button_should_sound (above) is false, this is ignored.
-    } bit;
+    struct _settings bit;
     uint32_t reg;
 } movement_settings_t;
 


### PR DESCRIPTION
For the compiler versions in the Nix flake, the settings struct is padded (at byte 15, right after the red LED color), resulting in the `button_volume` field running off the end of the value. Adding the __packed__ attribute fixes this, at least for the simulator.