### PR TITLE
fix .envrc failing when using direnv and not nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,7 @@
 # shellcheck shell=bash
+if [ -f /etc/NIXOS ]; then
 if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" "sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM="
 fi
 use flake
+fi


### PR DESCRIPTION
If you are using `direnv` but you are not using the nix falvour of linux, you get an error message as soon as you enter the project directory.