### PR TITLE
LIS2DW tap mode uses low-power mode

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -521,7 +521,7 @@ bool movement_enable_tap_detection_if_available(void) {
         // ramp data rate up to 400 Hz and high performance mode
         lis2dw_set_low_noise_mode(true);
         lis2dw_set_data_rate(LIS2DW_DATA_RATE_HP_400_HZ);
-        lis2dw_set_mode(LIS2DW_MODE_HIGH_PERFORMANCE);
+        lis2dw_set_mode(LIS2DW_MODE_LOW_POWER);
 
         // Settling time (1 sample duration, i.e. 1/400Hz)
         delay_ms(3);


### PR DESCRIPTION
In testing and reviewing the LIS2DW notes, I found that tap-detection works fine with Low Performance mode.
While 5.6.4 in the [Application notes](https://www.st.com/resource/en/application_note/an5038-lis2dw12-alwayson-3axis-accelerometer-stmicroelectronics.pdf) show the usage of high-performance mode, the [example from ST's C library](https://github.com/STMicroelectronics/STMems_Standard_C_drivers/blob/4cd7d1c4445b31f7dcca5f33bcb07fddb617ab34/lis2dw12_STdC/examples/lis2dw12_tap_single.c#L161) uses LIS2DW12_CONT_LOW_PWR_LOW_NOISE_12bit.

I tested this change out on my [Blackjack face](https://github.com/joeycastillo/second-movement/pull/111) and found no functional differences. But it does cause the watch to use a whopping 135uA less.

## Power Draw
### Blackjack Face With Tap Enabled
High Performance Mode | Low Performance Mode
:-------------------------:|:-------------------------:
<img width="1660" height="790" alt="blackjack-tap-on" src="https://github.com/user-attachments/assets/ca8db290-a2ff-4611-bd45-8062270aa2d8" /> | <img width="1660" height="790" alt="blackjack-tap-on-LP" src="https://github.com/user-attachments/assets/4caf57c5-9c76-4774-9257-879df1b7cd8f" />

### Blackjack Face With Tap Enabled And Tapping
High Performance Mode | Low Performance Mode
:-------------------------:|:-------------------------:
<img width="1660" height="790" alt="blackjack-tap-on-tapping" src="https://github.com/user-attachments/assets/da603b50-43c3-4807-ba9a-81037da6779d" /> | <img width="1660" height="790" alt="blackjack-tap-on-tapping-LP" src="https://github.com/user-attachments/assets/59a05e35-0ced-43dd-93bd-ff5eb62cf839" />



