### PR TITLE
Avoid out-of-range character

### DIFF
--- a/watch-library/shared/watch/watch_common_display.c
+++ b/watch-library/shared/watch/watch_common_display.c
@@ -43,6 +43,8 @@ uint8_t IndicatorSegments[8] = {
 };
 
 void watch_display_character(uint8_t character, uint8_t position) {
+    if((character-0x20 < 0) | (character-0x20 >= sizeof(Classic_LCD_Character_Set)) return ;
+
     if (watch_get_lcd_type() == WATCH_LCD_TYPE_CUSTOM) {
         if (character == 'R' && position > 1 && position < 8) character = 'r'; // We can't display uppercase R in these positions
         else if (character == 'T' && position > 1 && position < 8) character = 't'; // lowercase t is the only option for these positions
@@ -125,9 +127,9 @@ void watch_display_character(uint8_t character, uint8_t position) {
 
 void watch_display_character_lp_seconds(uint8_t character, uint8_t position) {
     // Will only work for digits and for positions  8 and 9 - but less code & checks to reduce power consumption
-
     digit_mapping_t segmap;
     uint8_t segdata;
+    if(character < 20) return ;
 
     /// TODO: See optimization note above.
 
@@ -169,6 +171,7 @@ void watch_display_string(const char *string, uint8_t position) {
 }
 
 void watch_display_text(watch_position_t location, const char *string) {
+    if(!string[0]) return ;
     switch (location) {
         case WATCH_POSITION_TOP:
         case WATCH_POSITION_TOP_LEFT:


### PR DESCRIPTION
When character is out of range, this will access illegal memory areas. 

In watch_display_text() it also makes sense to stop on char='\0' even when in position 0.