### PR TITLE
Revert "Avoid out-of-range character"

### DIFF
--- a/watch-library/shared/watch/watch_common_display.c
+++ b/watch-library/shared/watch/watch_common_display.c
@@ -43,8 +43,6 @@ uint8_t IndicatorSegments[8] = {
 };
 
 void watch_display_character(uint8_t character, uint8_t position) {
-    if((character-0x20 < 0) | (character-0x20 >= sizeof(Classic_LCD_Character_Set)) return ;
-
     if (watch_get_lcd_type() == WATCH_LCD_TYPE_CUSTOM) {
         if (character == 'R' && position > 1 && position < 8) character = 'r'; // We can't display uppercase R in these positions
         else if (character == 'T' && position > 1 && position < 8) character = 't'; // lowercase t is the only option for these positions
@@ -127,9 +125,9 @@ void watch_display_character(uint8_t character, uint8_t position) {
 
 void watch_display_character_lp_seconds(uint8_t character, uint8_t position) {
     // Will only work for digits and for positions  8 and 9 - but less code & checks to reduce power consumption
+
     digit_mapping_t segmap;
     uint8_t segdata;
-    if(character < 20) return ;
 
     /// TODO: See optimization note above.
 
@@ -171,7 +169,6 @@ void watch_display_string(const char *string, uint8_t position) {
 }
 
 void watch_display_text(watch_position_t location, const char *string) {
-    if(!string[0]) return ;
     switch (location) {
         case WATCH_POSITION_TOP:
         case WATCH_POSITION_TOP_LEFT:


### PR DESCRIPTION
Reverts joeycastillo/second-movement#153

Reverting to the below error:
```
watch-library/shared/watch/watch_common_display.c: In function 'watch_display_character':
watch-library/shared/watch/watch_common_display.c:46:47: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
watch-library/shared/watch/watch_common_display.c:46:84: error: expected ')' before 'return'
watch-library/shared/watch/watch_common_display.c:126:1: error: expected expression before '}' token
watch-library/shared/watch/watch_common_display.c:45:57: warning: unused parameter 'position' [-Wunused-parameter]
make: *** [gossamer/rules.mk:88: build/watch_common_display.o] Error 1
make: *** Waiting for unfinished jobs...
```