### PR TITLE
Fix write buffer issues

### DIFF
--- a/filesystem/filesystem.c
+++ b/filesystem/filesystem.c
@@ -253,7 +253,7 @@ static void filesystem_cat(char *filename) {
 
 bool filesystem_write_file(char *filename, char *text, int32_t length) {
     if (filesystem_get_free_space() <= 256) {
-        printf("No free space!\n");
+        printf("No free space!\r\n");
         return false;    
     }
 
@@ -266,7 +266,7 @@ bool filesystem_write_file(char *filename, char *text, int32_t length) {
 
 bool filesystem_append_file(char *filename, char *text, int32_t length) {
     if (filesystem_get_free_space() <= 256) {
-        printf("No free space!\n");
+        printf("No free space!\r\n");
         return false;    
     }
 
@@ -305,7 +305,7 @@ int filesystem_cmd_b64encode(int argc, char *argv[]) {
                 lfs_size_t len = min(12, info.size - i);
                 char base64_line[17];
                 b64_encode((unsigned char *)buf + i, len, (unsigned char *)base64_line);
-                printf("%s\n", base64_line);
+                printf("%s\r\n", base64_line);
                 delay_ms(10);
             }
             free(buf);


### PR DESCRIPTION
3 changes:
1. Flush the write buffer first if it is full rather than overwrite data
2. Fix bug in write loop causing it to exit early
3. Fix some inconsistent line endings in filesystem.c

This fixes the issue of the output being incorrect when outputting text over the serial connection. Part of https://github.com/joeycastillo/second-movement/issues/58
Catting large files and also the help function now outputs correctly every time:
```
swsh> ?                                                                                                   
Command List:                                                                                             
 ?      print command list                                                                                
 help   print command list                                                                                
 flash  reboot to UF2 bootloader                                                                          
 ls     usage: ls [PATH]                                                                                  
 cat    usage: cat <PATH>                                                                                 
 b64encode      usage: b64encode <PATH>                                                                   
 df     print filesystem free space                                                                       
 rm     usage: rm [PATH]                                                                                  
 format usage: format YES                                                                                 
 echo   usage: echo TEXT {>,>>} FILE                                                                      
 stress test CDC write; usage: stress [LEN] [DELAY_MS]
```

I have tested this on my sensorwatch pro using the serial connection and when in normal watch mode. 