### PR TITLE
Implement HOTP (counter-based) 2fa for totp_face

### DIFF
--- a/watch-faces/complication/totp_face.c
+++ b/watch-faces/complication/totp_face.c
@@ -119,10 +119,10 @@ static void totp_generate(totp_state_t *totp_state) {
     }
 
     TOTP(
-    totp_state->current_decoded_key,
-    totp_state->current_decoded_key_length,
-    totp->period,
-    totp->algorithm
+        totp_state->current_decoded_key,
+        totp_state->current_decoded_key_length,
+        totp->period,
+        totp->algorithm
     );
 
 }


### PR DESCRIPTION
Adds a counter field to the totp_state key and implements counter-based key generation (as opposed to time based).

CREDENTIALS is updated to add a counter-offset at initialization.

Indicate a HOTP key by setting the period to 0 (or 1). Long press the Alarm button to advance the counter and get a new key