### PR TITLE
Improved simulator watch RTC counter precision

### DIFF
--- a/watch-library/simulator/watch/watch_rtc.c
+++ b/watch-library/simulator/watch/watch_rtc.c
@@ -39,7 +39,6 @@ static uint32_t counter_interval;
 static uint32_t counter;
 static uint32_t reference_timestamp;
 static double next_tick_time;
-static double rtc_start_time;
 
 #define WATCH_RTC_N_COMP_CB 8
 
@@ -111,18 +110,7 @@ unix_timestamp_t watch_rtc_get_unix_time(void) {
 }
 
 rtc_counter_t watch_rtc_get_counter(void) {
-    if (!counter_interval) {
-        return counter; // RTC not running
-    }
-
-    // Calculate current counter from high-precision time
-    double now = EM_ASM_DOUBLE({ return performance.now(); });
-    double elapsed_ms = now - rtc_start_time;
-
-    // Convert elapsed time to RTC ticks (RTC_CNT_HZ = 128 Hz)
-    double elapsed_ticks = (elapsed_ms * RTC_CNT_HZ) / 1000.0;
-
-    return (rtc_counter_t)elapsed_ticks;
+    return counter;
 }
 
 uint32_t watch_rtc_get_frequency(void) {
@@ -183,7 +171,6 @@ static void _watch_schedule_next_tick(void) {
     if (!counter_interval) return;
 
     double now = EM_ASM_DOUBLE({ return performance.now(); });
-    double drift = now - next_tick_time;
 
     // Target interval in ms
     double ms = 1000.0 / (double)RTC_CNT_HZ;
@@ -192,13 +179,12 @@ static void _watch_schedule_next_tick(void) {
     next_tick_time += ms;
     double delay = next_tick_time - now;
 
-    // Ensure we don't schedule negative or zero delays
-    if (delay < 0.1) {
-        delay = 0.1;
-        next_tick_time = now + delay;
+    // If we're behind, schedule immediately
+    if (delay < 0) {
+        delay = 0;
     }
 
-    emscripten_async_call(_watch_increase_counter, NULL, (int)delay);
+    emscripten_async_call(_watch_increase_counter, NULL, delay);
 }
 
 static void _watch_increase_counter(void *userData) {
@@ -385,9 +371,7 @@ void watch_rtc_enable(bool en)
     if (en) {
         // Use drift-correcting timer instead of fixed setInterval
         counter_interval = 1; // Non-zero to indicate enabled
-        rtc_start_time = EM_ASM_DOUBLE({ return performance.now(); });
-        next_tick_time = rtc_start_time;
-        counter = 0;
+        next_tick_time = EM_ASM_DOUBLE({ return performance.now(); });
         _watch_schedule_next_tick();
     } else {
         counter_interval = 0;

--- a/watch-library/simulator/watch/watch_rtc.c
+++ b/watch-library/simulator/watch/watch_rtc.c
@@ -166,8 +166,6 @@ void watch_rtc_disable_tick_callback(void) {
     watch_rtc_disable_periodic_callback(1);
 }
 
-static void _watch_increase_counter(void *userData);
-
 static void _watch_schedule_next_tick(void) {
     if (!rtc_enabled) return;
 
@@ -180,10 +178,8 @@ static void _watch_schedule_next_tick(void) {
     next_tick_time += ms;
     double delay = next_tick_time - now;
 
-    // If we're behind, jump counter forward and reset timing
+    // If we're behind, reset timing
     if (delay < 0) {
-        uint32_t missed_ticks = (uint32_t)((-delay) / ms);
-        counter += missed_ticks;
         next_tick_time = now + ms;
         delay = ms;
     }

--- a/watch-library/simulator/watch/watch_rtc.c
+++ b/watch-library/simulator/watch/watch_rtc.c
@@ -180,9 +180,12 @@ static void _watch_schedule_next_tick(void) {
     next_tick_time += ms;
     double delay = next_tick_time - now;
 
-    // If we're behind, schedule immediately
+    // If we're behind, jump counter forward and reset timing
     if (delay < 0) {
-        delay = 0;
+        uint32_t missed_ticks = (uint32_t)((-delay) / ms);
+        counter += missed_ticks;
+        next_tick_time = now + ms;
+        delay = ms;
     }
 
     emscripten_async_call(_watch_increase_counter, NULL, delay);


### PR DESCRIPTION
While working on https://github.com/joeycastillo/second-movement/pull/62 I found myself in the need of improving watch RTC counter in simulator to be more precise. Here I'm cherry-picking the commit from the other PR so it can be merged separately.