### PR TITLE
Add archery face

### DIFF
--- a/movement_faces.h
+++ b/movement_faces.h
@@ -80,4 +80,5 @@
 #include "simon_face.h"
 #include "ping_face.h"
 #include "rtccount_face.h"
+#include "archery_face.h"
 // New includes go above this line.

--- a/watch-faces.mk
+++ b/watch-faces.mk
@@ -55,4 +55,5 @@ SRCS += \
   ./watch-faces/complication/lander_face.c \
   ./watch-faces/complication/simon_face.c \
   ./watch-faces/complication/ping_face.c \
+  ./watch-faces/complication/archery_face.c \
 # New watch faces go above this line.

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -214,6 +214,7 @@ bool archery_face_loop(movement_event_t event, void *context) {
                         state->round = wa_indoor;
                         state->minutes = INDOOR_RUN_MINUTES;
                     }
+                    button_beep();
                     break;
             }
             break;

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -1,0 +1,251 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 <#author_name#>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "watch_utility.h"
+#include "archery_face.h"
+
+#define WAIT_TIME_SECONDS 10
+#define INDOOR_RUN_MINUTES 2
+#define OUTDOOR_RUN_MINUTES 4
+
+static const int8_t _sound_seq_prepare[] = {BUZZER_NOTE_C6, 40, BUZZER_NOTE_REST, 40, -2, 1, 0};
+static const int8_t _sound_seq_start[] = {BUZZER_NOTE_C7, 50, 0};
+static const int8_t _sound_seq_30s[] = {BUZZER_NOTE_C6, 1, BUZZER_NOTE_REST, 2, -2, 3, 0};
+static const int8_t _sound_seq_end[] = {BUZZER_NOTE_C7, 40, BUZZER_NOTE_REST, 40, -2, 2, 0};
+
+static inline void load_countdown(archery_state_t *state) {
+    /* Load set countdown time */
+    state->minutes = state->set_minutes;
+    state->seconds = state->set_seconds;
+}
+
+static inline void store_countdown(archery_state_t *state) {
+    /* Store set countdown time */
+    state->set_minutes = state->minutes;
+    state->set_seconds = state->seconds;
+}
+
+static inline void button_beep() {
+    // play a beep as confirmation for a button press (if applicable)
+    if (movement_button_should_sound()) watch_buzzer_play_note_with_volume(BUZZER_NOTE_C8, 20, movement_button_volume());
+}
+
+static void schedule_countdown(archery_state_t *state) {
+    // Calculate the new state->now_ts but don't update it until we've updated the target
+    // avoid possible race where the old target is compared to the new time and immediately triggers
+    //
+    uint32_t new_now = watch_utility_date_time_to_unix_time(movement_get_utc_date_time(), movement_get_current_timezone_offset());
+    state->target_ts = watch_utility_offset_timestamp(new_now, 0, state->minutes, state->seconds);
+    state->now_ts = new_now;
+    watch_date_time_t target_dt = watch_utility_date_time_from_unix_time(state->target_ts, movement_get_current_timezone_offset());
+    movement_schedule_background_task_for_face(state->watch_face_index, target_dt);
+}
+
+static void start(archery_state_t *state) {
+    schedule_countdown(state);
+}
+
+static void draw(archery_state_t *state, uint8_t subsecond) {
+    char buf[16];
+    uint32_t delta;
+    div_t result;
+    switch (state->mode) {
+        case archery_prepare:
+        case archery_running:
+            if (state->target_ts <= state->now_ts)
+                delta = 0;
+            else
+                delta = state->target_ts - state->now_ts;
+            result = div(delta, 60);
+            state->seconds = result.rem;
+            result = div(result.quot, 60);
+            state->minutes = result.rem;
+            sprintf(buf, "  %02d%02d", state->minutes, state->seconds);
+            break;
+        case archery_reset:
+        case archery_paused:
+            watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+            sprintf(buf, "  %02d%02d", state->minutes, state->seconds);
+            break;
+        case archery_setting:
+            sprintf(buf, "  %02d%02d", state->minutes, state->seconds);
+            if (subsecond % 2) {
+                switch(state->selection) {
+                    case 0:
+                        buf[0] = buf[1] = ' ';
+                        break;
+                    case 1:
+                        buf[2] = buf[3] = ' ';
+                        break;
+                    case 2:
+                        buf[4] = buf[5] = ' ';
+                        break;
+                    default:
+                        break;
+                }
+            }
+            break;
+    }
+    watch_display_text(WATCH_POSITION_BOTTOM, buf);
+    watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+}
+
+static void pause(archery_state_t *state) {
+    state->prev_mode = state->mode;
+    state->mode = archery_paused;
+    movement_cancel_background_task_for_face(state->watch_face_index);
+    watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+}
+
+static void reset(archery_state_t *state) {
+    state->mode = archery_reset;
+    movement_cancel_background_task_for_face(state->watch_face_index);
+    load_countdown(state);
+}
+
+static void manage_stages(archery_state_t *state) {
+    if (state->mode == archery_prepare) {
+        state->minutes = INDOOR_RUN_MINUTES;
+        state->seconds = 0;
+        watch_buzzer_play_sequence((int8_t *)_sound_seq_start, NULL);
+        state->mode = archery_running;
+        schedule_countdown(state);
+    } else {
+        watch_buzzer_play_sequence((int8_t *)_sound_seq_end, NULL);
+        reset(state);
+    }
+}
+
+void archery_face_setup(uint8_t watch_face_index, void ** context_ptr) {
+    (void) watch_face_index;
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(archery_state_t));
+        archery_state_t *state = (archery_state_t *)*context_ptr;
+        memset(*context_ptr, 0, sizeof(archery_state_t));
+        state->minutes = INDOOR_RUN_MINUTES;
+        state->mode = archery_reset;
+        state->watch_face_index = watch_face_index;
+        store_countdown(state);
+    }
+}
+
+void archery_face_activate(void *context) {
+    archery_state_t *state = (archery_state_t *)context;
+    if(state->mode == archery_running) {
+        watch_date_time_t now = movement_get_utc_date_time();
+        state->now_ts = watch_utility_date_time_to_unix_time(now, movement_get_current_timezone_offset());
+        watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+    }
+    movement_request_tick_frequency(1);
+}
+
+bool archery_face_loop(movement_event_t event, void *context) {
+    archery_state_t *state = (archery_state_t *)context;
+
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            if (watch_sleep_animation_is_running()) watch_stop_sleep_animation();
+            watch_display_text(WATCH_POSITION_TOP, "WA");
+            draw(state, event.subsecond);
+            break;
+        case EVENT_TICK:
+            if (state->mode == archery_running || state->mode == archery_prepare) {
+                state->now_ts++;
+            }
+            draw(state, event.subsecond);
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            // You can use the Light button for your own purposes. Note that by default, Movement will also
+            // illuminate the LED in response to EVENT_LIGHT_BUTTON_DOWN; to suppress that behavior, add an
+            // empty case for EVENT_LIGHT_BUTTON_DOWN.
+            if (state->mode == archery_paused) {
+                reset(state);
+                button_beep();
+            }
+            break;
+        case EVENT_ALARM_BUTTON_DOWN:
+            switch (state->mode) {
+                case archery_prepare:
+                case archery_running:
+                    pause(state);
+                    button_beep();
+                    break;
+                case archery_reset:
+                    state->minutes = 0;
+                    state->seconds = 10;
+                    watch_buzzer_play_sequence((int8_t *)_sound_seq_prepare, NULL);
+                    state->mode = archery_prepare;
+                    start(state);
+                    watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+                    break;
+                case archery_paused:
+                    state->mode = state->prev_mode;
+                    start(state);
+                    button_beep();
+                    watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+                    break;
+                case archery_setting:
+                    //settings_increment(state);
+                    break;
+            }
+            draw(state, event.subsecond);
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            // Just in case you have need for another button.
+            break;
+        case EVENT_BACKGROUND_TASK:
+            manage_stages(state);
+            break;
+        case EVENT_TIMEOUT:
+            // Your watch face will receive this event after a period of inactivity. If it makes sense to resign,
+            // you may uncomment this line to move back to the first watch face in the list:
+            // movement_move_to_face(0);
+            break;
+        case EVENT_LOW_ENERGY_UPDATE:
+            // If you did not resign in EVENT_TIMEOUT, you can use this event to update the display once a minute.
+            // Avoid displaying fast-updating values like seconds, since the display won't update again for 60 seconds.
+            // You should also consider starting the tick animation, to show the wearer that this is sleep mode:
+            // watch_start_sleep_animation(500);
+            break;
+        default:
+            // Movement's default loop handler will step in for any cases you don't handle above:
+            // * EVENT_LIGHT_BUTTON_DOWN lights the LED
+            // * EVENT_MODE_BUTTON_UP moves to the next watch face in the list
+            // * EVENT_MODE_LONG_PRESS returns to the first watch face (or skips to the secondary watch face, if configured)
+            // You can override any of these behaviors by adding a case for these events to this switch statement.
+            return movement_default_loop_handler(event);
+    }
+
+    // return true if the watch can enter standby mode. Generally speaking, you should always return true.
+    return true;
+}
+
+void archery_face_resign(void *context) {
+    (void) context;
+
+    // handle any cleanup before your watch face goes off-screen.
+}
+

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -38,7 +38,9 @@ static const int8_t _sound_seq_end[] = {BUZZER_NOTE_C7, 40, BUZZER_NOTE_REST, 40
 
 static inline void button_beep() {
     // play a beep as confirmation for a button press (if applicable)
-    if (movement_button_should_sound()) watch_buzzer_play_note_with_volume(BUZZER_NOTE_C8, 20, movement_button_volume());
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C8, 20, movement_button_volume());
+    }
 }
 
 static void schedule_countdown(archery_state_t *state) {
@@ -169,9 +171,6 @@ bool archery_face_loop(movement_event_t event, void *context) {
             draw(state, event.subsecond);
             break;
         case EVENT_LIGHT_BUTTON_UP:
-            // You can use the Light button for your own purposes. Note that by default, Movement will also
-            // illuminate the LED in response to EVENT_LIGHT_BUTTON_DOWN; to suppress that behavior, add an
-            // empty case for EVENT_LIGHT_BUTTON_DOWN.
             if (state->mode == archery_paused) {
                 reset(state);
                 button_beep();
@@ -203,7 +202,6 @@ bool archery_face_loop(movement_event_t event, void *context) {
             draw(state, event.subsecond);
             break;
         case EVENT_LIGHT_LONG_PRESS:
-            // Just in case you have need for another button.
             switch (state->mode) {
                 case archery_prepare:
                 case archery_running:
@@ -229,18 +227,9 @@ bool archery_face_loop(movement_event_t event, void *context) {
             // Do not get back to face 0 on timeout but return on low energy below
             break;
         case EVENT_LOW_ENERGY_UPDATE:
-            // If you did not resign in EVENT_TIMEOUT, you can use this event to update the display once a minute.
-            // Avoid displaying fast-updating values like seconds, since the display won't update again for 60 seconds.
-            // You should also consider starting the tick animation, to show the wearer that this is sleep mode:
-            // watch_start_sleep_animation(500);
             movement_move_to_face(0);
             break;
         default:
-            // Movement's default loop handler will step in for any cases you don't handle above:
-            // * EVENT_LIGHT_BUTTON_DOWN lights the LED
-            // * EVENT_MODE_BUTTON_UP moves to the next watch face in the list
-            // * EVENT_MODE_LONG_PRESS returns to the first watch face (or skips to the secondary watch face, if configured)
-            // You can override any of these behaviors by adding a case for these events to this switch statement.
             return movement_default_loop_handler(event);
     }
 
@@ -250,7 +239,4 @@ bool archery_face_loop(movement_event_t event, void *context) {
 
 void archery_face_resign(void *context) {
     (void) context;
-
-    // handle any cleanup before your watch face goes off-screen.
 }
-

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -55,7 +55,7 @@ static void schedule_countdown(archery_state_t *state) {
 }
 
 static void draw(archery_state_t *state, uint8_t subsecond) {
-    char buf[16];
+    char buf[2][7];
     uint32_t delta;
     div_t result;
     switch (state->mode) {
@@ -67,7 +67,8 @@ static void draw(archery_state_t *state, uint8_t subsecond) {
                 delta = state->target_ts - state->now_ts;
             result = div(delta, 60);
             state->seconds = result.rem;
-            sprintf(buf, "rdy %02d", state->seconds);
+            sprintf(buf[0], "rdy %02d", state->seconds);
+            sprintf(buf[1], "rd  %02d", state->seconds);
             break;
         case archery_running:
             if (state->target_ts <= state->now_ts)
@@ -78,29 +79,33 @@ static void draw(archery_state_t *state, uint8_t subsecond) {
             state->seconds = result.rem;
             result = div(result.quot, 60);
             state->minutes = result.rem;
-            sprintf(buf, "  %02d%02d", state->minutes, state->seconds);
+            sprintf(buf[0], "  %02d%02d", state->minutes, state->seconds);
+            sprintf(buf[1], "  %02d%02d", state->minutes, state->seconds);
             break;
         case archery_reset:
-            sprintf(buf, "  %02d%02d", state->minutes, state->seconds);
+            sprintf(buf[0], "  %02d%02d", state->minutes, state->seconds);
+            sprintf(buf[1], "  %02d%02d", state->minutes, state->seconds);
             break;
         case archery_paused:
             watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
             if (state->before_pause_mode == archery_prepare) {
-                sprintf(buf, "rdy %02d", state->seconds);
+                sprintf(buf[0], "rdy %02d", state->seconds);
+                sprintf(buf[1], "rd  %02d", state->seconds);
             } else {
-                sprintf(buf, "  %02d%02d", state->minutes, state->seconds);
+                sprintf(buf[0], "  %02d%02d", state->minutes, state->seconds);
+                sprintf(buf[1], "  %02d%02d", state->minutes, state->seconds);
             }
             break;
     }
     switch (state->round) {
         case wa_indoor:
-            watch_display_text(WATCH_POSITION_TOP_RIGHT, "1n");
+            watch_display_text_with_fallback(WATCH_POSITION_TOP_RIGHT, "1n", " I");
             break;
         case wa_outdoor:
-            watch_display_text(WATCH_POSITION_TOP_RIGHT, "ou");
+            watch_display_text_with_fallback(WATCH_POSITION_TOP_RIGHT, "Ou", " O");
             break;
     }
-    watch_display_text(WATCH_POSITION_BOTTOM, buf);
+    watch_display_text_with_fallback(WATCH_POSITION_BOTTOM, buf[0], buf[1]);
     watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
 }
 

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -226,15 +226,14 @@ bool archery_face_loop(movement_event_t event, void *context) {
             manage_stages(state);
             break;
         case EVENT_TIMEOUT:
-            // Your watch face will receive this event after a period of inactivity. If it makes sense to resign,
-            // you may uncomment this line to move back to the first watch face in the list:
-            // movement_move_to_face(0);
+            // Do not get back to face 0 on timeout but return on low energy below
             break;
         case EVENT_LOW_ENERGY_UPDATE:
             // If you did not resign in EVENT_TIMEOUT, you can use this event to update the display once a minute.
             // Avoid displaying fast-updating values like seconds, since the display won't update again for 60 seconds.
             // You should also consider starting the tick animation, to show the wearer that this is sleep mode:
             // watch_start_sleep_animation(500);
+            movement_move_to_face(0);
             break;
         default:
             // Movement's default loop handler will step in for any cases you don't handle above:

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -83,7 +83,7 @@ static void draw(archery_state_t *state, uint8_t subsecond) {
             break;
         case archery_paused:
             watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
-            if (state->pre_pause_mode == archery_prepare) {
+            if (state->before_pause_mode == archery_prepare) {
                 sprintf(buf, "rdy %02d", state->seconds);
             } else {
                 sprintf(buf, "  %02d%02d", state->minutes, state->seconds);
@@ -103,7 +103,7 @@ static void draw(archery_state_t *state, uint8_t subsecond) {
 }
 
 static void pause(archery_state_t *state) {
-    state->pre_pause_mode = state->mode;
+    state->before_pause_mode = state->mode;
     state->mode = archery_paused;
     movement_cancel_background_task_for_face(state->watch_face_index);
     watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
@@ -194,7 +194,7 @@ bool archery_face_loop(movement_event_t event, void *context) {
                     watch_set_indicator(WATCH_INDICATOR_SIGNAL);
                     break;
                 case archery_paused:
-                    state->mode = state->pre_pause_mode;
+                    state->mode = state->before_pause_mode;
                     schedule_countdown(state);
                     button_beep();
                     watch_set_indicator(WATCH_INDICATOR_SIGNAL);

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -114,11 +114,11 @@ static void manage_stages(archery_state_t *state) {
     if (state->mode == archery_prepare) {
         state->minutes = state->round == wa_indoor ? INDOOR_RUN_MINUTES : OUTDOOR_RUN_MINUTES;
         state->seconds = 0;
-        watch_buzzer_play_sequence((int8_t *)_sound_seq_start, NULL);
+        watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_start, NULL, movement_alarm_volume());
         state->mode = archery_running;
         schedule_countdown(state);
     } else {
-        watch_buzzer_play_sequence((int8_t *)_sound_seq_end, NULL);
+        watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_end, NULL, movement_alarm_volume());
         reset(state);
     }
 }
@@ -181,7 +181,7 @@ bool archery_face_loop(movement_event_t event, void *context) {
                 case archery_reset:
                     state->minutes = 0;
                     state->seconds = 10;
-                    watch_buzzer_play_sequence((int8_t *)_sound_seq_prepare, NULL);
+                    watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_prepare, NULL, movement_alarm_volume());
                     state->mode = archery_prepare;
                     schedule_countdown(state);
                     watch_set_indicator(WATCH_INDICATOR_SIGNAL);

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -58,6 +58,15 @@ static void draw(archery_state_t *state, uint8_t subsecond) {
     div_t result;
     switch (state->mode) {
         case archery_prepare:
+            // Semi-duplicated code but it's probably more energy efficient
+            if (state->target_ts <= state->now_ts)
+                delta = 0;
+            else
+                delta = state->target_ts - state->now_ts;
+            result = div(delta, 60);
+            state->seconds = result.rem;
+            sprintf(buf, "rdy %02d", state->seconds);
+            break;
         case archery_running:
             if (state->target_ts <= state->now_ts)
                 delta = 0;

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -81,7 +81,11 @@ static void draw(archery_state_t *state, uint8_t subsecond) {
         case archery_reset:
         case archery_paused:
             watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
-            sprintf(buf, "  %02d%02d", state->minutes, state->seconds);
+            if (state->pre_pause_mode == archery_prepare) {
+                sprintf(buf, "rdy %02d", state->seconds);
+            } else {
+                sprintf(buf, "  %02d%02d", state->minutes, state->seconds);
+            }
             break;
     }
     switch (state->round) {

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -176,6 +176,7 @@ bool archery_face_loop(movement_event_t event, void *context) {
                 reset(state);
                 button_beep();
             }
+            draw(state, event.subsecond);
             break;
         case EVENT_ALARM_BUTTON_DOWN:
             switch (state->mode) {
@@ -219,6 +220,7 @@ bool archery_face_loop(movement_event_t event, void *context) {
                     button_beep();
                     break;
             }
+            draw(state, event.subsecond);
             break;
         case EVENT_BACKGROUND_TASK:
             manage_stages(state);

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -79,6 +79,8 @@ static void draw(archery_state_t *state, uint8_t subsecond) {
             sprintf(buf, "  %02d%02d", state->minutes, state->seconds);
             break;
         case archery_reset:
+            sprintf(buf, "  %02d%02d", state->minutes, state->seconds);
+            break;
         case archery_paused:
             watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
             if (state->pre_pause_mode == archery_prepare) {

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -38,7 +38,7 @@ static const int8_t _sound_seq_end[] = {BUZZER_NOTE_C7, 28, BUZZER_NOTE_REST, 36
 static inline void button_beep() {
     // play a beep as confirmation for a button press (if applicable)
     if (movement_button_should_sound()) {
-        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 30, movement_button_volume());
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 20, movement_button_volume());
     }
 }
 

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -31,9 +31,9 @@ static const int8_t WAIT_TIME_SECONDS = 10;
 static const int8_t INDOOR_RUN_MINUTES = 2;
 static const int8_t OUTDOOR_RUN_MINUTES = 4;
 
-static const int8_t _sound_seq_prepare[] = {BUZZER_NOTE_C6, 30, BUZZER_NOTE_REST, 30, -2, 1, 0};
-static const int8_t _sound_seq_start[] = {BUZZER_NOTE_C7, 40, 0};
-static const int8_t _sound_seq_end[] = {BUZZER_NOTE_C7, 30, BUZZER_NOTE_REST, 30, -2, 2, 0};
+static const int8_t _sound_seq_prepare[] = {BUZZER_NOTE_C6, 16, BUZZER_NOTE_REST, 16, -2, 1, 0};
+static const int8_t _sound_seq_start[] = {BUZZER_NOTE_C7, 24, 0};
+static const int8_t _sound_seq_end[] = {BUZZER_NOTE_C7, 28, BUZZER_NOTE_REST, 36, -2, 2, 0};
 
 static inline void button_beep() {
     // play a beep as confirmation for a button press (if applicable)

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -33,7 +33,6 @@ static const int8_t OUTDOOR_RUN_MINUTES = 4;
 
 static const int8_t _sound_seq_prepare[] = {BUZZER_NOTE_C6, 40, BUZZER_NOTE_REST, 40, -2, 1, 0};
 static const int8_t _sound_seq_start[] = {BUZZER_NOTE_C7, 50, 0};
-static const int8_t _sound_seq_30s[] = {BUZZER_NOTE_C6, 1, BUZZER_NOTE_REST, 2, -2, 3, 0};
 static const int8_t _sound_seq_end[] = {BUZZER_NOTE_C7, 40, BUZZER_NOTE_REST, 40, -2, 2, 0};
 
 static inline void button_beep() {

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2026 <#author_name#>
+ * Copyright (c) 2026 Davide Girardi
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -174,7 +174,7 @@ bool archery_face_loop(movement_event_t event, void *context) {
             }
             draw(state, event.subsecond);
             break;
-        case EVENT_LIGHT_BUTTON_UP:
+        case EVENT_LIGHT_BUTTON_DOWN:
             if (state->mode == archery_paused) {
                 reset(state);
                 button_beep();

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -230,10 +230,9 @@ bool archery_face_loop(movement_event_t event, void *context) {
             manage_stages(state);
             break;
         case EVENT_TIMEOUT:
-            // Do not get back to face 0 on timeout but return on low energy below
+            movement_move_to_face(0);
             break;
         case EVENT_LOW_ENERGY_UPDATE:
-            movement_move_to_face(0);
             break;
         default:
             return movement_default_loop_handler(event);

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -126,11 +126,11 @@ static void manage_stages(archery_state_t *state) {
     if (state->mode == archery_prepare) {
         state->minutes = state->round == wa_indoor ? INDOOR_RUN_MINUTES : OUTDOOR_RUN_MINUTES;
         state->seconds = 0;
-        watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_start, NULL, movement_signal_volume());
+        watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_start, NULL, WATCH_BUZZER_VOLUME_SOFT);
         state->mode = archery_running;
         schedule_countdown(state);
     } else {
-        watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_end, NULL, movement_signal_volume());
+        watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_end, NULL, WATCH_BUZZER_VOLUME_SOFT);
         reset(state);
     }
 }
@@ -193,7 +193,7 @@ bool archery_face_loop(movement_event_t event, void *context) {
                 case archery_reset:
                     state->minutes = 0;
                     state->seconds = 10;
-                    watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_prepare, NULL, movement_signal_volume());
+                    watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_prepare, NULL, WATCH_BUZZER_VOLUME_SOFT);
                     state->mode = archery_prepare;
                     schedule_countdown(state);
                     watch_set_indicator(WATCH_INDICATOR_SIGNAL);

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -126,11 +126,11 @@ static void manage_stages(archery_state_t *state) {
     if (state->mode == archery_prepare) {
         state->minutes = state->round == wa_indoor ? INDOOR_RUN_MINUTES : OUTDOOR_RUN_MINUTES;
         state->seconds = 0;
-        watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_start, NULL, movement_alarm_volume());
+        watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_start, NULL, movement_signal_volume());
         state->mode = archery_running;
         schedule_countdown(state);
     } else {
-        watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_end, NULL, movement_alarm_volume());
+        watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_end, NULL, movement_signal_volume());
         reset(state);
     }
 }
@@ -193,7 +193,7 @@ bool archery_face_loop(movement_event_t event, void *context) {
                 case archery_reset:
                     state->minutes = 0;
                     state->seconds = 10;
-                    watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_prepare, NULL, movement_alarm_volume());
+                    watch_buzzer_play_sequence_with_volume((int8_t *)_sound_seq_prepare, NULL, movement_signal_volume());
                     state->mode = archery_prepare;
                     schedule_countdown(state);
                     watch_set_indicator(WATCH_INDICATOR_SIGNAL);

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -175,10 +175,11 @@ bool archery_face_loop(movement_event_t event, void *context) {
             draw(state, event.subsecond);
             break;
         case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
             if (state->mode == archery_paused) {
                 reset(state);
                 button_beep();
+            } else {
+                movement_illuminate_led();
             }
             draw(state, event.subsecond);
             break;

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -39,7 +39,7 @@ static const int8_t _sound_seq_end[] = {BUZZER_NOTE_C7, 40, BUZZER_NOTE_REST, 40
 static inline void button_beep() {
     // play a beep as confirmation for a button press (if applicable)
     if (movement_button_should_sound()) {
-        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C8, 20, movement_button_volume());
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 30, movement_button_volume());
     }
 }
 

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -175,6 +175,7 @@ bool archery_face_loop(movement_event_t event, void *context) {
             draw(state, event.subsecond);
             break;
         case EVENT_LIGHT_BUTTON_DOWN:
+            movement_illuminate_led();
             if (state->mode == archery_paused) {
                 reset(state);
                 button_beep();

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -31,9 +31,9 @@ static const int8_t WAIT_TIME_SECONDS = 10;
 static const int8_t INDOOR_RUN_MINUTES = 2;
 static const int8_t OUTDOOR_RUN_MINUTES = 4;
 
-static const int8_t _sound_seq_prepare[] = {BUZZER_NOTE_C6, 40, BUZZER_NOTE_REST, 40, -2, 1, 0};
-static const int8_t _sound_seq_start[] = {BUZZER_NOTE_C7, 50, 0};
-static const int8_t _sound_seq_end[] = {BUZZER_NOTE_C7, 40, BUZZER_NOTE_REST, 40, -2, 2, 0};
+static const int8_t _sound_seq_prepare[] = {BUZZER_NOTE_C6, 30, BUZZER_NOTE_REST, 30, -2, 1, 0};
+static const int8_t _sound_seq_start[] = {BUZZER_NOTE_C7, 40, 0};
+static const int8_t _sound_seq_end[] = {BUZZER_NOTE_C7, 30, BUZZER_NOTE_REST, 30, -2, 2, 0};
 
 static inline void button_beep() {
     // play a beep as confirmation for a button press (if applicable)

--- a/watch-faces/complication/archery_face.c
+++ b/watch-faces/complication/archery_face.c
@@ -174,6 +174,11 @@ bool archery_face_loop(movement_event_t event, void *context) {
             }
             draw(state, event.subsecond);
             break;
+#ifdef FORCE_GSHOCK_LCD_TYPE
+        case EVENT_LIGHT_BUTTON_DOWN:
+            movement_illuminate_led();
+            break;
+#else
         case EVENT_LIGHT_BUTTON_DOWN:
             if (state->mode == archery_paused) {
                 reset(state);
@@ -183,6 +188,7 @@ bool archery_face_loop(movement_event_t event, void *context) {
             }
             draw(state, event.subsecond);
             break;
+#endif
         case EVENT_ALARM_BUTTON_DOWN:
             switch (state->mode) {
                 case archery_prepare:
@@ -207,11 +213,20 @@ bool archery_face_loop(movement_event_t event, void *context) {
             }
             draw(state, event.subsecond);
             break;
+#ifdef FORCE_GSHOCK_LCD_TYPE
+        case EVENT_ADJUST_BUTTON_DOWN:
+#else
         case EVENT_LIGHT_LONG_PRESS:
+#endif
             switch (state->mode) {
+                case archery_paused:
+#ifdef FORCE_GSHOCK_LCD_TYPE
+                    reset(state);
+                    button_beep();
+                    break;
+#endif
                 case archery_prepare:
                 case archery_running:
-                case archery_paused:
                     break;
                 case archery_reset:
                     if (state->round == wa_indoor) {

--- a/watch-faces/complication/archery_face.h
+++ b/watch-faces/complication/archery_face.h
@@ -27,13 +27,27 @@
 #include "movement.h"
 
 /*
- * A DESCRIPTION OF YOUR WATCH FACE
+ * WORLD ARCHERY TARGET ROUNDS FACE
  *
- * and a description of how use it
+ * Timing for world archery target rounds with 2 auditory signals, 10 seconds
+ * preparation and then a countdown for the round itself.
  *
+ * Long press light button to switch the configuration between 2 minutes for
+ * indoor, reflected by "in" in the top right corner, and 4 minutes for
+ * outdoors, indicated by "ou" insted.
+ *
+ * Start the countdown by pressing the alarm button. The watch will mimic the
+ * behavior you would expect in a competition, with the extra possibility of
+ * pausing whenever you want. Stages:
+ * - 2 audible signals will ring at the start of the 10 seconds preparation
+ *   time (the watch will show "rdy")
+ * - 1 signal will indicate that round start
+ * - 3 final signals indicate a timeout
+ *
+ * Pressing the alarm button while the timer is running will pause the
+ * countdown (during the prepration too). You can reset the timer by pressing
+ * the light button.
  */
-
-// TODO: base on countdown_face as first step instead
 
 typedef enum {
     wa_indoor,

--- a/watch-faces/complication/archery_face.h
+++ b/watch-faces/complication/archery_face.h
@@ -36,11 +36,15 @@
 // TODO: base on countdown_face as first step instead
 
 typedef enum {
+    wa_indoor,
+    wa_outdoor,
+} archery_round_t;
+
+typedef enum {
     archery_paused,
     archery_prepare,
     archery_running,
-    archery_setting,
-    archery_reset
+    archery_reset,
 } archery_mode_t;
 
 typedef struct {
@@ -50,9 +54,9 @@ typedef struct {
     uint8_t seconds;
     uint8_t set_minutes;
     uint8_t set_seconds;
-    uint8_t selection;
     archery_mode_t mode;
-    archery_mode_t prev_mode;
+    archery_mode_t pre_pause_mode;
+    archery_round_t round;
     uint8_t watch_face_index;
 } archery_state_t;
 

--- a/watch-faces/complication/archery_face.h
+++ b/watch-faces/complication/archery_face.h
@@ -49,6 +49,11 @@
  * the light button.
  *
  * Heavily based on the countdown face
+ *
+ * The indicators for the classic display are:
+ * - I for indoor rounds
+ * - O for outdoor
+ * - rd for the preparation time
  */
 
 typedef enum {

--- a/watch-faces/complication/archery_face.h
+++ b/watch-faces/complication/archery_face.h
@@ -47,6 +47,8 @@
  * Pressing the alarm button while the timer is running will pause the
  * countdown (during the prepration too). You can reset the timer by pressing
  * the light button.
+ *
+ * Heavily based on the countdown face
  */
 
 typedef enum {

--- a/watch-faces/complication/archery_face.h
+++ b/watch-faces/complication/archery_face.h
@@ -1,0 +1,70 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 <#author_name#>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "movement.h"
+
+/*
+ * A DESCRIPTION OF YOUR WATCH FACE
+ *
+ * and a description of how use it
+ *
+ */
+
+// TODO: base on countdown_face as first step instead
+
+typedef enum {
+    archery_paused,
+    archery_prepare,
+    archery_running,
+    archery_setting,
+    archery_reset
+} archery_mode_t;
+
+typedef struct {
+    uint32_t target_ts;
+    uint32_t now_ts;
+    uint8_t minutes;
+    uint8_t seconds;
+    uint8_t set_minutes;
+    uint8_t set_seconds;
+    uint8_t selection;
+    archery_mode_t mode;
+    archery_mode_t prev_mode;
+    uint8_t watch_face_index;
+} archery_state_t;
+
+void archery_face_setup(uint8_t watch_face_index, void ** context_ptr);
+void archery_face_activate(void *context);
+bool archery_face_loop(movement_event_t event, void *context);
+void archery_face_resign(void *context);
+
+#define archery_face ((const watch_face_t){ \
+    archery_face_setup, \
+    archery_face_activate, \
+    archery_face_loop, \
+    archery_face_resign, \
+    NULL, \
+})

--- a/watch-faces/complication/archery_face.h
+++ b/watch-faces/complication/archery_face.h
@@ -69,7 +69,7 @@ typedef struct {
     uint8_t set_minutes;
     uint8_t set_seconds;
     archery_mode_t mode;
-    archery_mode_t pre_pause_mode;
+    archery_mode_t before_pause_mode;
     archery_round_t round;
     uint8_t watch_face_index;
 } archery_state_t;

--- a/watch-faces/complication/archery_face.h
+++ b/watch-faces/complication/archery_face.h
@@ -29,12 +29,19 @@
 /*
  * WORLD ARCHERY TARGET ROUNDS FACE
  *
- * Timing for world archery target rounds with 2 auditory signals, 10 seconds
- * preparation and then a countdown for the round itself.
+ * Simulate the timing of World Archery competitions. There are two modes:
+ * indoor and outdoor.
+ *
+ * Indoor rounds last 2 minutes and outdoor ones last 4 minutes. You can switch
+ * mode by long pressing the light button.
+ *
+ * When starting the timer, the watch will beep 2 times, count down from 10
+ * seconds to 0 for the preparation phase, beep once and then start the 2 or 4
+ * minutes countdown. When the countdown reaches 0 the watch will beep 3 times.
  *
  * Long press light button to switch the configuration between 2 minutes for
  * indoor, reflected by "in" in the top right corner, and 4 minutes for
- * outdoors, indicated by "ou" insted.
+ * outdoors, indicated by "ou" instead.
  *
  * Start the countdown by pressing the alarm button. The watch will mimic the
  * behavior you would expect in a competition, with the extra possibility of
@@ -45,7 +52,7 @@
  * - 3 final signals indicate a timeout
  *
  * Pressing the alarm button while the timer is running will pause the
- * countdown (during the prepration too). You can reset the timer by pressing
+ * countdown (during the preparation too). You can reset the timer by pressing
  * the light button.
  *
  * Heavily based on the countdown face

--- a/watch-faces/complication/archery_face.h
+++ b/watch-faces/complication/archery_face.h
@@ -51,8 +51,6 @@
  * - 1 signal will indicate that round start
  * - 3 final signals indicate a timeout
  *
- * The volume of the signal is the same of the hourly signal
- *
  * Pressing the alarm button while the timer is running will pause the
  * countdown (during the preparation too). You can reset the timer by pressing
  * the light button.

--- a/watch-faces/complication/archery_face.h
+++ b/watch-faces/complication/archery_face.h
@@ -51,6 +51,8 @@
  * - 1 signal will indicate that round start
  * - 3 final signals indicate a timeout
  *
+ * The volume of the signal is the same of the hourly signal
+ *
  * Pressing the alarm button while the timer is running will pause the
  * countdown (during the preparation too). You can reset the timer by pressing
  * the light button.

--- a/watch-faces/complication/archery_face.h
+++ b/watch-faces/complication/archery_face.h
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2026 <#author_name#>
+ * Copyright (c) 2026 Davide Girardi
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/watch-faces/complication/archery_face.h
+++ b/watch-faces/complication/archery_face.h
@@ -33,15 +33,16 @@
  * indoor and outdoor.
  *
  * Indoor rounds last 2 minutes and outdoor ones last 4 minutes. You can switch
- * mode by long pressing the light button.
+ * mode by long pressing the light button on Sensor Watch or by pressing adjust
+ * on Jolt.
  *
  * When starting the timer, the watch will beep 2 times, count down from 10
  * seconds to 0 for the preparation phase, beep once and then start the 2 or 4
  * minutes countdown. When the countdown reaches 0 the watch will beep 3 times.
  *
- * Long press light button to switch the configuration between 2 minutes for
- * indoor, reflected by "in" in the top right corner, and 4 minutes for
- * outdoors, indicated by "ou" instead.
+ * Long press light button on Sensor Watch, or press adjust on Jolt, to switch
+ * the configuration between 2 minutes for indoor, reflected by "in" in the top
+ * right corner, and 4 minutes for outdoors, indicated by "ou" instead.
  *
  * Start the countdown by pressing the alarm button. The watch will mimic the
  * behavior you would expect in a competition, with the extra possibility of
@@ -53,7 +54,7 @@
  *
  * Pressing the alarm button while the timer is running will pause the
  * countdown (during the preparation too). You can reset the timer by pressing
- * the light button.
+ * the light button, adjust on Jolt.
  *
  * Heavily based on the countdown face
  *


### PR DESCRIPTION
Add an archery face to simulate the timing of World Archery competitions. There are two modes: indoor and outdoor.

Indoor rounds last 2 minutes and outdoor ones last 4 minutes. You can switch mode by long pressing the light button.

When starting the timer, the watch will beep 2 times, count down from 10 seconds to 0, beep once and then start the 2 or 4 minutes countdown. When the countdown reaches 0 the watch will beep 3 times.

For more information, see the header file.

I tested this only on the emulator but tried it both with the classic and custom displays.