### PR TITLE
Fix calling start callback

### DIFF
--- a/watch-library/hardware/watch/watch_tcc.c
+++ b/watch-library/hardware/watch/watch_tcc.c
@@ -230,7 +230,7 @@ void watch_buzzer_abort_sequence(void) {
 }
 
 void watch_buzzer_register_global_callbacks(watch_cb_t cb_start, watch_cb_t cb_stop) {
-    _cb_stop_global = cb_start;
+    _cb_start_global = cb_start;
     _cb_stop_global = cb_stop;
 }
 

--- a/watch-library/simulator/watch/watch_tcc.c
+++ b/watch-library/simulator/watch/watch_tcc.c
@@ -200,7 +200,7 @@ void watch_buzzer_abort_sequence(void) {
 }
 
 void watch_buzzer_register_global_callbacks(watch_cb_t cb_start, watch_cb_t cb_stop) {
-    _cb_stop_global = cb_start;
+    _cb_start_global = cb_start;
     _cb_stop_global = cb_stop;
 }
 


### PR DESCRIPTION
Fix `watch_buzzer_register_global_callbacks` in the hardware and emulator implementations.