### PR TITLE
Add quiet time

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -585,7 +585,7 @@ void movement_play_note(watch_buzzer_note_t note, uint16_t duration_ms) {
 }
 
 void movement_play_signal(void) {
-    movement_play_sequence(signal_tune, BUZZER_PRIORITY_SIGNAL);
+    if (!movement_is_quiet_time()) movement_play_sequence(signal_tune, BUZZER_PRIORITY_SIGNAL);
 }
 
 void movement_play_alarm(void) {
@@ -743,9 +743,14 @@ void movement_set_utc_timestamp(uint32_t timestamp) {
     _movement_update_dst_offset_cache();
 }
 
+bool movement_button_sound_enabled(void) {
+    // This is the value set by the user
+    return movement_state.settings.bit.button_should_sound;
+}
 
 bool movement_button_should_sound(void) {
-    return movement_state.settings.bit.button_should_sound;
+    // This is a combination of the setting and if we are outside of quiet time
+    return movement_state.settings.bit.button_should_sound && !movement_is_quiet_time();
 }
 
 void movement_set_button_should_sound(bool value) {
@@ -781,6 +786,18 @@ watch_buzzer_volume_t movement_signal_volume(void) {
 }
 void movement_set_signal_volume(watch_buzzer_volume_t value) {
     movement_state.signal_volume = value;
+}
+
+bool movement_is_quiet_time(void) {
+    uint8_t start = movement_state.settings.bit.quiet_time_start;
+    uint8_t stop = movement_state.settings.bit.quiet_time_stop;
+    uint32_t hours = movement_get_local_date_time().unit.hour;
+    // Normalize around the clock so we can manage both start > stop and start < stop
+    // Adding 24 avoids negative numbers which would overflow
+    stop = (24 + stop - start) % 24;
+    hours = (24 + hours - start) % 24;
+    if (0 <= hours && hours < stop) return true;
+    return false;
 }
 
 watch_buzzer_volume_t movement_alarm_volume(void) {
@@ -1254,7 +1271,7 @@ static bool _switch_face(void) {
     watch_clear_display();
     movement_request_tick_frequency(1);
 
-    if (movement_state.settings.bit.button_should_sound) {
+    if (movement_button_should_sound()) {
         // low note for nonzero case, high note for return to watch_face 0
         movement_play_note(movement_state.next_face_idx ? BUZZER_NOTE_C7 : BUZZER_NOTE_C8, 50);
     }

--- a/movement.c
+++ b/movement.c
@@ -756,6 +756,22 @@ watch_buzzer_volume_t movement_button_volume(void) {
     return movement_state.settings.bit.button_volume;
 }
 
+uint8_t movement_get_quiet_time_start(void) {
+    return movement_state.settings.bit.quiet_time_start;
+}
+
+void movement_set_quiet_time_start(uint8_t value) {
+    movement_state.settings.bit.quiet_time_start = value;
+}
+
+uint8_t movement_get_quiet_time_stop(void) {
+    return movement_state.settings.bit.quiet_time_stop;
+}
+
+void movement_set_quiet_time_stop(uint8_t value) {
+    movement_state.settings.bit.quiet_time_stop = value;
+}
+
 void movement_set_button_volume(watch_buzzer_volume_t value) {
     movement_state.settings.bit.button_volume = value;
 }
@@ -1029,6 +1045,8 @@ void app_init(void) {
     #endif
         movement_state.settings.bit.button_should_sound = MOVEMENT_DEFAULT_BUTTON_SOUND;
         movement_state.settings.bit.button_volume = MOVEMENT_DEFAULT_BUTTON_VOLUME;
+        movement_state.settings.bit.quiet_time_start = MOVEMENT_DEFAULT_QUIET_TIME_START;
+        movement_state.settings.bit.quiet_time_stop = MOVEMENT_DEFAULT_QUIET_TIME_STOP;
         movement_state.settings.bit.to_interval = MOVEMENT_DEFAULT_TIMEOUT_INTERVAL;
 #ifdef MOVEMENT_LOW_ENERGY_MODE_FORBIDDEN
         movement_state.settings.bit.le_interval = 0;

--- a/movement.h
+++ b/movement.h
@@ -336,6 +336,7 @@ void movement_request_wake(void);
 
 void movement_play_note(watch_buzzer_note_t note, uint16_t duration_ms);
 void movement_play_signal(void);
+bool movement_is_quiet_time(void);
 void movement_play_alarm(void);
 void movement_play_alarm_beeps(uint8_t rounds, watch_buzzer_note_t alarm_note);
 void movement_play_sequence(int8_t *note_sequence, movement_buzzer_priority_t priority);
@@ -359,6 +360,7 @@ void movement_set_utc_date_time(watch_date_time_t date_time);
 void movement_set_local_date_time(watch_date_time_t date_time);
 void movement_set_utc_timestamp(uint32_t timestamp);
 
+bool movement_button_sound_enabled(void);
 bool movement_button_should_sound(void);
 void movement_set_button_should_sound(bool value);
 

--- a/movement.h
+++ b/movement.h
@@ -86,6 +86,9 @@ typedef union {
         bool use_imperial_units : 1;        // indicates whether to use metric units (the default) or imperial.
         
         bool button_volume : 1;             // 0 for soft beep, 1 for loud beep. If button_should_sound (above) is false, this is ignored.
+
+        uint8_t quiet_time_start: 5;
+        uint8_t quiet_time_stop: 5;
     } bit;
     uint32_t reg;
 } movement_settings_t;
@@ -361,6 +364,12 @@ void movement_set_button_should_sound(bool value);
 
 watch_buzzer_volume_t movement_button_volume(void);
 void movement_set_button_volume(watch_buzzer_volume_t value);
+
+uint8_t movement_get_quiet_time_start(void);
+void movement_set_quiet_time_start(uint8_t value);
+
+uint8_t movement_get_quiet_time_stop(void);
+void movement_set_quiet_time_stop(uint8_t value);
 
 watch_buzzer_volume_t movement_signal_volume(void);
 void movement_set_signal_volume(watch_buzzer_volume_t value);

--- a/movement_config.h
+++ b/movement_config.h
@@ -71,9 +71,11 @@ const watch_face_t watch_faces[] = {
 #define MOVEMENT_DEFAULT_SIGNAL_VOLUME WATCH_BUZZER_VOLUME_LOUD
 #define MOVEMENT_DEFAULT_ALARM_VOLUME WATCH_BUZZER_VOLUME_LOUD
 
-/* Do not beep on button presses nor sound the hourly chimes between these hours */
-#define MOVEMENT_DEFAULT_QUIET_TIME_START 8
-#define MOVEMENT_DEFAULT_QUIET_TIME_STOP 13
+/* Do not beep on button presses nor sound the hourly chimes between these hours 
+ * Set them to the same value here or at runtime to disable the feature
+ */
+#define MOVEMENT_DEFAULT_QUIET_TIME_START 0
+#define MOVEMENT_DEFAULT_QUIET_TIME_STOP 0
 
 /* Set the timeout before switching back to the main watch face
  * Valid values are:

--- a/movement_config.h
+++ b/movement_config.h
@@ -71,6 +71,10 @@ const watch_face_t watch_faces[] = {
 #define MOVEMENT_DEFAULT_SIGNAL_VOLUME WATCH_BUZZER_VOLUME_LOUD
 #define MOVEMENT_DEFAULT_ALARM_VOLUME WATCH_BUZZER_VOLUME_LOUD
 
+/* Do not beep on button presses nor sound the hourly chimes between these hours */
+#define MOVEMENT_DEFAULT_QUIET_TIME_START 8
+#define MOVEMENT_DEFAULT_QUIET_TIME_STOP 13
+
 /* Set the timeout before switching back to the main watch face
  * Valid values are:
  * 0: 60 seconds

--- a/watch-faces/settings/settings_face.c
+++ b/watch-faces/settings/settings_face.c
@@ -286,6 +286,41 @@ static void git_hash_setting_advance(void) {
     return;
 }
 
+
+static void quiet_time_start_setting_display(uint8_t subsecond) {
+    char buf[3];
+    uint8_t hours = movement_get_quiet_time_start();
+    watch_display_text_with_fallback(WATCH_POSITION_TOP, "mute", "mute");
+    watch_display_text(WATCH_POSITION_BOTTOM, "  strt");
+    if (subsecond % 2) {
+        sprintf(buf, "%2d", hours);
+        watch_display_text(WATCH_POSITION_HOURS, buf);
+    }
+}
+
+static void quiet_time_start_setting_advance(void) {
+    uint8_t hours = movement_get_quiet_time_start();
+    hours = (hours + 1) % 24;
+    movement_set_quiet_time_start(hours);
+}
+
+static void quiet_time_stop_setting_display(uint8_t subsecond) {
+    char buf[3];
+    uint8_t hours = movement_get_quiet_time_stop();
+    watch_display_text_with_fallback(WATCH_POSITION_TOP, "mute", "mute");
+    watch_display_text(WATCH_POSITION_BOTTOM, "  stop");
+    if (subsecond % 2) {
+        sprintf(buf, "%2d", hours);
+        watch_display_text(WATCH_POSITION_HOURS, buf);
+    }
+}
+
+static void quiet_time_stop_setting_advance(void) {
+    uint8_t hours = movement_get_quiet_time_stop();
+    hours = (hours + 1) % 24;
+    movement_set_quiet_time_stop(hours);
+}
+
 void settings_face_setup(uint8_t watch_face_index, void ** context_ptr) {
     (void) watch_face_index;
     if (*context_ptr == NULL) {
@@ -293,7 +328,7 @@ void settings_face_setup(uint8_t watch_face_index, void ** context_ptr) {
         settings_state_t *state = (settings_state_t *)*context_ptr;
         int8_t current_setting = 0;
 
-        state->num_settings = 6; // baseline, without LED settings
+        state->num_settings = 8; // baseline, without LED settings
 #ifndef MOVEMENT_LOW_ENERGY_MODE_FORBIDDEN
         state->num_settings++;
 #endif
@@ -311,6 +346,12 @@ void settings_face_setup(uint8_t watch_face_index, void ** context_ptr) {
 #endif
 
         state->settings_screens = malloc(state->num_settings * sizeof(settings_screen_t));
+        state->settings_screens[current_setting].display = quiet_time_start_setting_display;
+        state->settings_screens[current_setting].advance = quiet_time_start_setting_advance;
+        current_setting++;
+        state->settings_screens[current_setting].display = quiet_time_stop_setting_display;
+        state->settings_screens[current_setting].advance = quiet_time_stop_setting_advance;
+        current_setting++;
         state->settings_screens[current_setting].display = clock_setting_display;
         state->settings_screens[current_setting].advance = clock_setting_advance;
         current_setting++;

--- a/watch-faces/settings/settings_face.c
+++ b/watch-faces/settings/settings_face.c
@@ -42,7 +42,7 @@ static void beep_setting_display(uint8_t subsecond) {
     watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "BTN", "BT");
     watch_display_text_with_fallback(WATCH_POSITION_BOTTOM, "beep  ", " beep ");
     if (subsecond % 2) {
-        if (movement_button_should_sound()) {
+        if (movement_button_sound_enabled()) {
             if (movement_button_volume() == WATCH_BUZZER_VOLUME_LOUD) {
                 // H for HIGH
                 watch_display_text(WATCH_POSITION_TOP_RIGHT, " H");
@@ -59,7 +59,7 @@ static void beep_setting_display(uint8_t subsecond) {
 }
 
 static void beep_setting_advance(void) {
-    if (!movement_button_should_sound()) {
+    if (!movement_button_sound_enabled()) {
         // was muted. make it soft.
         movement_set_button_should_sound(true);
         movement_set_button_volume(WATCH_BUZZER_VOLUME_SOFT);

--- a/watch-faces/settings/settings_face.c
+++ b/watch-faces/settings/settings_face.c
@@ -292,6 +292,15 @@ static void quiet_time_start_setting_display(uint8_t subsecond) {
     uint8_t hours = movement_get_quiet_time_start();
     watch_display_text_with_fallback(WATCH_POSITION_TOP, "mute", "mute");
     watch_display_text(WATCH_POSITION_BOTTOM, "  strt");
+    if (movement_clock_mode_24h()) {
+        watch_set_indicator(WATCH_INDICATOR_24H);
+    } else {
+        watch_clear_indicator(WATCH_INDICATOR_24H);
+        if (hours >= 12) watch_set_indicator(WATCH_INDICATOR_PM);
+        else watch_clear_indicator(WATCH_INDICATOR_PM);
+        // Format the hours value for display since we don't neeto to perform more checks
+        hours = (hours % 12) ? (hours % 12) : 12;
+    }
     if (subsecond % 2) {
         sprintf(buf, "%2d", hours);
         watch_display_text(WATCH_POSITION_HOURS, buf);
@@ -309,6 +318,15 @@ static void quiet_time_stop_setting_display(uint8_t subsecond) {
     uint8_t hours = movement_get_quiet_time_stop();
     watch_display_text_with_fallback(WATCH_POSITION_TOP, "mute", "mute");
     watch_display_text(WATCH_POSITION_BOTTOM, "  stop");
+    if (movement_clock_mode_24h()) {
+        watch_set_indicator(WATCH_INDICATOR_24H);
+    } else {
+        watch_clear_indicator(WATCH_INDICATOR_24H);
+        if (hours >= 12) watch_set_indicator(WATCH_INDICATOR_PM);
+        else watch_clear_indicator(WATCH_INDICATOR_PM);
+        // Format the hours value for display since we don't neeto to perform more checks
+        hours = (hours % 12) ? (hours % 12) : 12;
+    }
     if (subsecond % 2) {
         sprintf(buf, "%2d", hours);
         watch_display_text(WATCH_POSITION_HOURS, buf);

--- a/watch-faces/settings/settings_face.c
+++ b/watch-faces/settings/settings_face.c
@@ -290,7 +290,7 @@ static void git_hash_setting_advance(void) {
 static void quiet_time_start_setting_display(uint8_t subsecond) {
     char buf[3];
     uint8_t hours = movement_get_quiet_time_start();
-    watch_display_text_with_fallback(WATCH_POSITION_TOP, "mute", "mute");
+    watch_display_text_with_fallback(WATCH_POSITION_TOP, "Amute", "AM");
     watch_display_text(WATCH_POSITION_BOTTOM, "  strt");
     if (movement_clock_mode_24h()) {
         watch_set_indicator(WATCH_INDICATOR_24H);
@@ -316,7 +316,7 @@ static void quiet_time_start_setting_advance(void) {
 static void quiet_time_stop_setting_display(uint8_t subsecond) {
     char buf[3];
     uint8_t hours = movement_get_quiet_time_stop();
-    watch_display_text_with_fallback(WATCH_POSITION_TOP, "mute", "mute");
+    watch_display_text_with_fallback(WATCH_POSITION_TOP, "Amute", "AM");
     watch_display_text(WATCH_POSITION_BOTTOM, "  stop");
     if (movement_clock_mode_24h()) {
         watch_set_indicator(WATCH_INDICATOR_24H);

--- a/watch-faces/settings/settings_face.c
+++ b/watch-faces/settings/settings_face.c
@@ -346,12 +346,6 @@ void settings_face_setup(uint8_t watch_face_index, void ** context_ptr) {
 #endif
 
         state->settings_screens = malloc(state->num_settings * sizeof(settings_screen_t));
-        state->settings_screens[current_setting].display = quiet_time_start_setting_display;
-        state->settings_screens[current_setting].advance = quiet_time_start_setting_advance;
-        current_setting++;
-        state->settings_screens[current_setting].display = quiet_time_stop_setting_display;
-        state->settings_screens[current_setting].advance = quiet_time_stop_setting_advance;
-        current_setting++;
         state->settings_screens[current_setting].display = clock_setting_display;
         state->settings_screens[current_setting].advance = clock_setting_advance;
         current_setting++;
@@ -363,6 +357,12 @@ void settings_face_setup(uint8_t watch_face_index, void ** context_ptr) {
         current_setting++;
         state->settings_screens[current_setting].display = alarm_setting_display;
         state->settings_screens[current_setting].advance = alarm_setting_advance;
+        current_setting++;
+        state->settings_screens[current_setting].display = quiet_time_start_setting_display;
+        state->settings_screens[current_setting].advance = quiet_time_start_setting_advance;
+        current_setting++;
+        state->settings_screens[current_setting].display = quiet_time_stop_setting_display;
+        state->settings_screens[current_setting].advance = quiet_time_stop_setting_advance;
         current_setting++;
         state->settings_screens[current_setting].display = timeout_setting_display;
         state->settings_screens[current_setting].advance = timeout_setting_advance;


### PR DESCRIPTION
Add quiet time: an interval of hours where button beeps and chimes are suppressed.

This implementation calls a function every time one of those sound should play. In other words the function is called every time you press a button or when performing an hourly signal.

The function itself needs to get the current time.

I'd like to know from the reviewer(s) if this is an issue from a battery usage point of view.

I also had to duplicate a lot of code for displaying the settings page. It's basically the exact same 2 functions but with start and stop swapped. Is there a better way?