### PR TITLE
Countdown: Disable double tap

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -845,7 +845,7 @@ void movement_set_alarm_enabled(bool value) {
     movement_state.alarm_enabled = value;
 }
 
-bool movement_enable_tap_detection_if_available(void) {
+bool movement_enable_tap_detection_if_available(bool enable_double_tap) {
     if (movement_state.has_lis2dw) {
         // configure tap duration threshold and enable Z axis
         lis2dw_configure_tap_threshold(0, 0, 12, LIS2DW_REG_TAP_THS_Z_Z_AXIS_ENABLE);
@@ -855,13 +855,20 @@ bool movement_enable_tap_detection_if_available(void) {
         lis2dw_set_low_noise_mode(true);
         lis2dw_set_data_rate(LIS2DW_DATA_RATE_HP_400_HZ);
         lis2dw_set_mode(LIS2DW_MODE_LOW_POWER);
-        lis2dw_enable_double_tap();
+
+        if (enable_double_tap) {
+            lis2dw_enable_double_tap();
+        }
 
         // Settling time (1 sample duration, i.e. 1/400Hz)
         delay_ms(3);
 
         // enable tap detection on INT1/A3.
-        lis2dw_configure_int1(LIS2DW_CTRL4_INT1_SINGLE_TAP | LIS2DW_CTRL4_INT1_DOUBLE_TAP);
+        uint8_t int1_sources = LIS2DW_CTRL4_INT1_SINGLE_TAP;
+        if (enable_double_tap) {
+            int1_sources |= LIS2DW_CTRL4_INT1_DOUBLE_TAP;
+        }
+        lis2dw_configure_int1(int1_sources);
 
         return true;
     }

--- a/movement.h
+++ b/movement.h
@@ -395,7 +395,7 @@ bool movement_alarm_enabled(void);
 void movement_set_alarm_enabled(bool value);
 
 // if the board has an accelerometer, these functions will enable or disable tap detection.
-bool movement_enable_tap_detection_if_available(void);
+bool movement_enable_tap_detection_if_available(bool enable_double_tap);
 bool movement_disable_tap_detection_if_available(void);
 
 // gets and sets the accelerometer data rate in the background

--- a/watch-faces/complication/blackjack_face.c
+++ b/watch-faces/complication/blackjack_face.c
@@ -354,7 +354,7 @@ static void handle_button_presses(bool tap_control_on, bool hit) {
     {
     case BJ_TITLE_SCREEN:
         if (!tap_turned_on && tap_control_on) {
-            if (movement_enable_tap_detection_if_available()) tap_turned_on = true;
+            if (movement_enable_tap_detection_if_available(true)) tap_turned_on = true;
         }
         begin_playing(tap_control_on);
         break;
@@ -384,7 +384,7 @@ static void toggle_tap_control(blackjack_face_state_t *state) {
         state->tap_control_on = false;
         watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
     } else {
-        bool tap_could_enable = movement_enable_tap_detection_if_available();
+        bool tap_could_enable = movement_enable_tap_detection_if_available(true);
         if (tap_could_enable) {
             state->tap_control_on = true;
             watch_set_indicator(WATCH_INDICATOR_SIGNAL);

--- a/watch-faces/complication/countdown_face.c
+++ b/watch-faces/complication/countdown_face.c
@@ -218,7 +218,7 @@ void countdown_face_activate(void *context) {
 
     movement_request_tick_frequency(1);
     quick_ticks_running = false;
-    if (state->mode != cd_running && movement_enable_tap_detection_if_available()) {
+    if (state->mode != cd_running && movement_enable_tap_detection_if_available(true)) {
         state->tap_detection_ticks = TAP_DETECTION_SECONDS;
         state->has_tapped_once = false;
     }

--- a/watch-faces/complication/countdown_face.c
+++ b/watch-faces/complication/countdown_face.c
@@ -218,7 +218,7 @@ void countdown_face_activate(void *context) {
 
     movement_request_tick_frequency(1);
     quick_ticks_running = false;
-    if (state->mode != cd_running && movement_enable_tap_detection_if_available(true)) {
+    if (state->mode != cd_running && movement_enable_tap_detection_if_available(false)) {
         state->tap_detection_ticks = TAP_DETECTION_SECONDS;
         state->has_tapped_once = false;
     }

--- a/watch-faces/complication/endless_runner_face.c
+++ b/watch-faces/complication/endless_runner_face.c
@@ -327,7 +327,7 @@ static void toggle_sound(endless_runner_state_t *state) {
 
 static void enable_tap_control(endless_runner_state_t *state) {
     if (!state->tap_control_on) {
-        movement_enable_tap_detection_if_available();
+        movement_enable_tap_detection_if_available(true);
         state->tap_control_on = true;
     }
 }

--- a/watch-faces/complication/ping_face.c
+++ b/watch-faces/complication/ping_face.c
@@ -367,7 +367,7 @@ static void toggle_sound(ping_state_t *state) {
 
 static void enable_tap_control(ping_state_t *state) {
     if (!state->tap_control_on) {
-        movement_enable_tap_detection_if_available();
+        movement_enable_tap_detection_if_available(true);
         state->tap_control_on = true;
     }
 }

--- a/watch-faces/complication/probability_face.c
+++ b/watch-faces/complication/probability_face.c
@@ -237,7 +237,7 @@ void probability_face_activate(void *context)
     movement_request_tick_frequency(1);
 
     // Enable tap detection for a few seconds when face is activated
-    if (movement_enable_tap_detection_if_available()) {
+    if (movement_enable_tap_detection_if_available(true)) {
         state->tap_detection_ticks = TAP_DETECTION_SECONDS;
     }
 }


### PR DESCRIPTION
On the countdown face, with double tap enabled, one had to tap not too fast on the watch to increment the minutes regularly. Otherwise, some taps would be discarded.

This made using the countdown face without looking at the screen for acknowledgement of taps impossible.

It was also impossible to increment minutes quickly, every second tap would be discarded.

This is one of the faces I use the most. Single tap was the behaviour prior to double tap being enabled a wee while ago.

& that project is great! Thanks for all the efforts : )

### Testing done

Built & used on watch: ✅