### PR TITLE
flake.nix: Add python313

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
             pkgs.gnumake
             pkgs.emscripten
             pkgs.gcc-arm-embedded
+            pkgs.python313
           ];
           shellHook = ''
             export EM_CACHE=$(pwd)/.emscripten_cache/


### PR DESCRIPTION
Python is needed to run `uf2conv`, so the final build step will fail without it. Most folks will have a global Python to fall back to, but this change fixes the build for those who don't, and makes the Nix environment more complete.