### PR TITLE
Fix ppm fractional display on finetune Frq page

### DIFF
--- a/watch-faces/settings/finetune_face.c
+++ b/watch-faces/settings/finetune_face.c
@@ -87,7 +87,7 @@ static void finetune_update_display(void) {
             float correction = finetune_get_correction();
             watch_display_text(WATCH_POSITION_TOP_RIGHT, (total_adjustment < 0) ? " -" : "  ");
 
-            sprintf(buf, "%2d%04d", (int)fabsf(correction), (int)(remainderf(fabsf(correction), 1.) * 10000));
+            sprintf(buf, "%2d%04d", (int)fabsf(correction), (int)(fmodf(fabsf(correction), 1.) * 10000));
             watch_display_text(WATCH_POSITION_BOTTOM, buf);
         }
     }


### PR DESCRIPTION
The Frq page used remainderf to extract the fractional part of the correction value, but remainderf rounds to the nearest integer and returns negative results when the fraction exceeds 0.5. This caused values like 0.965 ppm to render as " 0-350" instead of " 09650". Switch to fmodf, matching the DELtA page above.