### PR TITLE
Settings display no longer clears every second as it shows a flicker on some watches

### DIFF
--- a/watch-faces/settings/settings_face.c
+++ b/watch-faces/settings/settings_face.c
@@ -31,6 +31,8 @@ static void clock_setting_display(uint8_t subsecond) {
     if (subsecond % 2) {
         if (movement_clock_mode_24h()) watch_display_text(WATCH_POSITION_BOTTOM, "24h");
         else watch_display_text(WATCH_POSITION_BOTTOM, "12h");
+    } else {
+        watch_display_text(WATCH_POSITION_BOTTOM, "      ");
     }
 }
 
@@ -55,6 +57,8 @@ static void beep_setting_display(uint8_t subsecond) {
             // N for NONE
             watch_display_text(WATCH_POSITION_TOP_RIGHT, " N");
         }
+    } else {
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, "  ");
     }
 }
 
@@ -89,6 +93,8 @@ static void signal_setting_display(uint8_t subsecond) {
             // L for LOW
             watch_display_text(WATCH_POSITION_TOP_RIGHT, " L");
         }
+    } else {
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, "  ");
     }
 }
 
@@ -118,6 +124,8 @@ static void alarm_setting_display(uint8_t subsecond) {
             // L for LOW
             watch_display_text(WATCH_POSITION_TOP_RIGHT, " L");
         }
+    } else {
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, "  ");
     }
 }
 
@@ -152,6 +160,8 @@ static void timeout_setting_display(uint8_t subsecond) {
                 watch_display_text(WATCH_POSITION_BOTTOM, "30n&in");
                 break;
         }
+    } else {
+        watch_display_text(WATCH_POSITION_BOTTOM, "      ");
     }
 }
 
@@ -188,6 +198,8 @@ static void low_energy_setting_display(uint8_t subsecond) {
                 watch_display_text(WATCH_POSITION_BOTTOM, " 7 day");
                 break;
         }
+    } else {
+        watch_display_text(WATCH_POSITION_BOTTOM, "      ");
     }
 }
 
@@ -208,6 +220,8 @@ static void led_duration_setting_display(uint8_t subsecond) {
             sprintf(buf, " %1d SeC", (movement_get_backlight_dwell() * 2 - 1) % 10);
             watch_display_text(WATCH_POSITION_BOTTOM, buf);
         }
+    } else {
+        watch_display_text(WATCH_POSITION_BOTTOM, "      ");
     }
 }
 
@@ -228,6 +242,8 @@ static void red_led_setting_display(uint8_t subsecond) {
     if (subsecond % 2) {
         sprintf(buf, "%2d", color.red);
         watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+    } else {
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, "  ");
     }
 }
 
@@ -246,6 +262,8 @@ static void green_led_setting_display(uint8_t subsecond) {
     if (subsecond % 2) {
         sprintf(buf, "%2d", color.green);
         watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+    } else {
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, "  ");
     }
 }
 
@@ -264,6 +282,8 @@ static void blue_led_setting_display(uint8_t subsecond) {
     if (subsecond % 2) {
         sprintf(buf, "%2d", color.blue);
         watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+    } else {
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, "  ");
     }
 }
 
@@ -380,10 +400,10 @@ bool settings_face_loop(movement_event_t event, void *context) {
     switch (event.event_type) {
         case EVENT_LIGHT_BUTTON_DOWN:
             state->current_page = (state->current_page + 1) % state->num_settings;
+            watch_clear_display();
             // fall through
         case EVENT_TICK:
         case EVENT_ACTIVATE:
-            watch_clear_display();
             state->settings_screens[state->current_page].display(event.subsecond);
             break;
         case EVENT_MODE_BUTTON_UP:


### PR DESCRIPTION
I noticed on watch faces with a 1/4 LCD bias, that there is a flicker on the non-changing characters in the settings face.
This change makes it so the full display doesn't clear on every second, and instead, only the flashing characters get overwritten.