### PR TITLE
Metronome face

### DIFF
--- a/movement_faces.h
+++ b/movement_faces.h
@@ -83,4 +83,5 @@
 #include "tomato_face.h"
 #include "solar_time_face.h"
 #include "tide_face.h"
+#include "metronome_face.h"
 // New includes go above this line.

--- a/watch-faces.mk
+++ b/watch-faces.mk
@@ -58,4 +58,5 @@ SRCS += \
   ./watch-faces/complication/tomato_face.c \
   ./watch-faces/clock/solar_time_face.c \
   ./watch-faces/complication/tide_face.c \
+  ./watch-faces/complication/metronome_face.c \
 # New watch faces go above this line.

--- a/watch-faces/complication/metronome_face.c
+++ b/watch-faces/complication/metronome_face.c
@@ -253,6 +253,7 @@ void metronome_face_activate(void *context) {
     metronome_state_t *metronome = context;
 
     metronome->ticking = false;
+    metronome->setting = false;
     metronome->beep = false;
 
     if (metronome->bpm < METRONOME_BPM_MIN || metronome->bpm > METRONOME_BPM_MAX) {

--- a/watch-faces/complication/metronome_face.c
+++ b/watch-faces/complication/metronome_face.c
@@ -36,12 +36,16 @@
 
 #define METRONOME_BPM_DEFAULT (120u)
 #define METRONOME_BPM_MIN     (40u)
-#define METRONOME_BPM_MAX     (180u)
+#define METRONOME_BPM_MAX     (209u)
 
 typedef struct {
     bool ticking;
     bool beep;
     bool ticktock;
+    bool setting;
+    bool setting_scroll;
+    bool setting_flasher;
+    uint8_t setting_item;
     uint8_t bpm;
     uint16_t ticks_calc;
     uint16_t ticks_calc_remainder;
@@ -57,6 +61,14 @@ static void metronome_display_title(metronome_state_t *metronome) {
 static void metronome_display_bpm(metronome_state_t *metronome) {
     char buf[7];
     snprintf(buf, sizeof(buf), "%3u", metronome->bpm);
+    // If we're in setting mode, blank out the item we're setting every other tick.
+    if (metronome->setting && !metronome->setting_scroll && !metronome->setting_flasher) {
+        if (metronome->setting_item == 0) {
+            buf[0] = buf[1] = ' ';
+        } else {
+            buf[2] = ' ';
+        }
+    }
     watch_display_text(WATCH_POSITION_BOTTOM, buf);
 }
 
@@ -86,28 +98,58 @@ static void metronome_stop_ticking(metronome_state_t *metronome) {
     metronome->ticking = false;
 }
 
-static void metronome_tick(metronome_state_t *metronome) {
-    if (!metronome->ticking) { return; }
-
-    if (metronome->ticks_countdown)
-        metronome->ticks_countdown--;
-    if (metronome->ticks_countdown == 0) {
-        metronome->ticks_countdown = metronome->ticks_calc;
-        metronome->ticks_count_remainder += metronome->ticks_calc_remainder;
-        if (metronome->ticks_count_remainder >= metronome->bpm) {
-            metronome->ticks_count_remainder -= metronome->bpm;
-            if (metronome->ticks_count_remainder >= metronome->bpm) {
-                metronome->ticks_count_remainder = 0;
-            }
-            metronome->ticks_countdown++;
-        }
-        metronome->ticktock = !metronome->ticktock;
-        if (metronome->ticktock)
-            watch_display_text(WATCH_POSITION_SECONDS, "# ");
+static void settings_increment(metronome_state_t *metronome) {
+    if (metronome->setting_item == 0) {
+        // Increment the tens digit of the BPM, with wrap-around.
+        if (metronome->bpm + 10u <= METRONOME_BPM_MAX)
+            metronome->bpm += 10u;
         else
-            watch_display_text(WATCH_POSITION_SECONDS, " #");
-        if (metronome->beep)
-            watch_buzzer_play_note(BUZZER_NOTE_C8, 50);
+            metronome->bpm = (METRONOME_BPM_MIN - (METRONOME_BPM_MIN % 10u)) + (metronome->bpm % 10u);
+    } else {
+        // Increment the ones digit of the BPM, with wrap-around.
+        metronome->bpm = metronome->bpm - (metronome->bpm % 10u) + ((metronome->bpm + 1u) % 10u);
+    }
+}
+
+static void metronome_tick(metronome_state_t *metronome) {
+    if (metronome->setting) {
+        if (metronome->setting_scroll) {
+            if (HAL_GPIO_BTN_ALARM_read()) {
+                settings_increment(metronome);
+                metronome_ticks_calc(metronome);
+            }
+        } else {
+            // Flash the item being set.
+            metronome->setting_flasher = !metronome->setting_flasher;
+        }
+        metronome_display_bpm(metronome);
+    }
+    if (metronome->ticking) {
+        if (metronome->ticks_countdown)
+            metronome->ticks_countdown--;
+        if (metronome->ticks_countdown == 0) {
+            // A metronome beat has occurred.
+            // Reset the countdown.
+            metronome->ticks_countdown = metronome->ticks_calc;
+            // Update the remainder counter. If it overflows, increase the next countdown.
+            // This provides more accurate BPM on average, at the cost of some jitter in the short term.
+            metronome->ticks_count_remainder += metronome->ticks_calc_remainder;
+            if (metronome->ticks_count_remainder >= metronome->bpm) {
+                metronome->ticks_count_remainder -= metronome->bpm;
+                if (metronome->ticks_count_remainder >= metronome->bpm)
+                    metronome->ticks_count_remainder = 0;
+                metronome->ticks_countdown++;
+            }
+            // Display the tick or tock in the seconds position.
+            metronome->ticktock = !metronome->ticktock;
+            if (metronome->ticktock)
+                watch_display_text(WATCH_POSITION_SECONDS, "# ");
+            else
+                watch_display_text(WATCH_POSITION_SECONDS, " #");
+            // Beep if enabled.
+            if (metronome->beep)
+                watch_buzzer_play_note(BUZZER_NOTE_C8, 50);
+        }
     }
 }
 
@@ -148,25 +190,83 @@ bool metronome_face_loop(movement_event_t event, void *context) {
 
     switch (event.event_type) {
         case EVENT_ALARM_BUTTON_UP:
-            if (metronome->bpm < METRONOME_BPM_MAX) {
-                metronome->bpm++;
-                metronome_ticks_calc(metronome);
-                metronome_display_bpm(metronome);
+            if (metronome->setting) {
+                if (metronome->setting_scroll) {
+                    metronome->setting_scroll = false;
+                    movement_request_tick_frequency(4);
+                } else {
+                    settings_increment(metronome);
+                    metronome_ticks_calc(metronome);
+                }
+            } else {
+                if (metronome->bpm < METRONOME_BPM_MAX) {
+                    metronome->bpm++;
+                    metronome_ticks_calc(metronome);
+                    metronome_display_bpm(metronome);
+                }
+            }
+            break;
+        case EVENT_ALARM_LONG_UP:
+            if (metronome->setting) {
+                if (metronome->setting_scroll) {
+                    metronome->setting_scroll = false;
+                    movement_request_tick_frequency(4);
+                }
+            }
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            if (metronome->setting) {
+                if (!metronome->setting_scroll) {
+                    // Start to scroll the BPM number.
+                    metronome->setting_scroll = true;
+                    metronome->setting_flasher = false;
+                    movement_request_tick_frequency(8);
+                }
+                metronome->setting_scroll = true;
+            } else {
+                // Entering setting mode, stop ticking and reset settings.
+                metronome->setting = true;
+                metronome->setting_flasher = false;
+                metronome->setting_scroll = false;
+                metronome->setting_item = 0;
+                metronome_stop_ticking(metronome);
+                movement_request_tick_frequency(4);
             }
             break;
         case EVENT_LIGHT_BUTTON_DOWN:
             // Inhibit the LED
             break;
         case EVENT_LIGHT_BUTTON_UP:
-            if (metronome->bpm > METRONOME_BPM_MIN) {
-                metronome->bpm--;
-                metronome_ticks_calc(metronome);
-                metronome_display_bpm(metronome);
+            if (metronome->setting) {
+                if (metronome->setting_item == 0) {
+                    // Move to the ones digit of the BPM.
+                    metronome->setting_item = 1;
+                } else {
+                    // Exit setting mode, start ticking again.
+                    metronome->setting = false;
+                    metronome_display_bpm(metronome);
+                    metronome_start_ticking(metronome);
+                }
+            } else {
+                // Decrement the BPM.
+                if (metronome->bpm > METRONOME_BPM_MIN) {
+                    metronome->bpm--;
+                    metronome_ticks_calc(metronome);
+                    metronome_display_bpm(metronome);
+                }
             }
             break;
         case EVENT_LIGHT_LONG_PRESS:
-            metronome->beep = !metronome->beep;
-            metronome_indicate_beep(metronome);
+            if (metronome->setting) {
+                // Reset to default BPM.
+                metronome->bpm = METRONOME_BPM_DEFAULT;
+                metronome_ticks_calc(metronome);
+                metronome->setting_item = 0;
+            } else {
+                // Toggle beep on/off.
+                metronome->beep = !metronome->beep;
+                metronome_indicate_beep(metronome);
+            }
             break;
         case EVENT_TICK:
             metronome_tick(metronome);

--- a/watch-faces/complication/metronome_face.c
+++ b/watch-faces/complication/metronome_face.c
@@ -55,7 +55,7 @@ typedef struct {
 
 static void metronome_display_title(metronome_state_t *metronome) {
     (void) metronome;
-    watch_display_text_with_fallback(WATCH_POSITION_TOP, "METRO", "ME");
+    watch_display_text_with_fallback(WATCH_POSITION_TOP, "MET", "ME");
 }
 
 static void metronome_display_bpm(metronome_state_t *metronome) {

--- a/watch-faces/complication/metronome_face.c
+++ b/watch-faces/complication/metronome_face.c
@@ -98,7 +98,71 @@ static void metronome_stop_ticking(metronome_state_t *metronome) {
     metronome->ticking = false;
 }
 
-static void settings_increment(metronome_state_t *metronome) {
+// Tick handler while metronome->ticking is true.
+static void running_tick(metronome_state_t *metronome) {
+    if (metronome->ticks_countdown)
+        metronome->ticks_countdown--;
+    if (metronome->ticks_countdown == 0) {
+        // A metronome beat has occurred.
+        // Reset the countdown.
+        metronome->ticks_countdown = metronome->ticks_calc;
+        // Update the remainder counter. If it overflows, increase the next countdown.
+        // This provides more accurate BPM on average, at the cost of some jitter in the short term.
+        metronome->ticks_count_remainder += metronome->ticks_calc_remainder;
+        if (metronome->ticks_count_remainder >= metronome->bpm) {
+            metronome->ticks_count_remainder -= metronome->bpm;
+            if (metronome->ticks_count_remainder >= metronome->bpm)
+                metronome->ticks_count_remainder = 0;
+            metronome->ticks_countdown++;
+        }
+        // Display the tick or tock in the seconds position.
+        metronome->ticktock = !metronome->ticktock;
+        if (metronome->ticktock)
+            watch_display_text(WATCH_POSITION_SECONDS, "# ");
+        else
+            watch_display_text(WATCH_POSITION_SECONDS, " #");
+        // Beep if enabled.
+        if (metronome->beep)
+            watch_buzzer_play_note(BUZZER_NOTE_C8, 50);
+    }
+}
+
+// Increment the BPM while running.
+static void running_bpm_inc(metronome_state_t *metronome) {
+    if (metronome->bpm < METRONOME_BPM_MAX) {
+        metronome->bpm++;
+        metronome_ticks_calc(metronome);
+        metronome_display_bpm(metronome);
+    }
+}
+
+// Decrement the BPM while running.
+static void running_bpm_dec(metronome_state_t *metronome) {
+    if (metronome->bpm > METRONOME_BPM_MIN) {
+        metronome->bpm--;
+        metronome_ticks_calc(metronome);
+        metronome_display_bpm(metronome);
+    }
+}
+
+// Enter setting mode, stop ticking and reset settings.
+static void setting_enter(metronome_state_t *metronome) {
+    metronome->setting = true;
+    metronome->setting_flasher = false;
+    metronome->setting_scroll = false;
+    metronome->setting_item = 0;
+    metronome_stop_ticking(metronome);
+    watch_display_text(WATCH_POSITION_SECONDS, "  ");
+    movement_request_tick_frequency(4);
+}
+
+static void setting_exit(metronome_state_t *metronome) {
+    metronome->setting = false;
+    metronome_display_bpm(metronome);
+    metronome_start_ticking(metronome);
+}
+
+static void setting_digit_inc(metronome_state_t *metronome) {
     if (metronome->setting_item == 0) {
         // Increment the tens digit of the BPM, with wrap-around.
         if (metronome->bpm + 10u <= METRONOME_BPM_MAX)
@@ -107,50 +171,67 @@ static void settings_increment(metronome_state_t *metronome) {
             metronome->bpm = (METRONOME_BPM_MIN - (METRONOME_BPM_MIN % 10u)) + (metronome->bpm % 10u);
     } else {
         // Increment the ones digit of the BPM, with wrap-around.
-        metronome->bpm = metronome->bpm - (metronome->bpm % 10u) + ((metronome->bpm + 1u) % 10u);
+        metronome->bpm = metronome->bpm + (((metronome->bpm + 1u) % 10u) ? 1 : -9);
     }
 }
 
-static void metronome_tick(metronome_state_t *metronome) {
-    if (metronome->setting) {
-        if (metronome->setting_scroll) {
-            if (HAL_GPIO_BTN_ALARM_read()) {
-                settings_increment(metronome);
-                metronome_ticks_calc(metronome);
-            }
-        } else {
-            // Flash the item being set.
-            metronome->setting_flasher = !metronome->setting_flasher;
-        }
-        metronome_display_bpm(metronome);
+static void setting_button_up_inc(metronome_state_t *metronome) {
+    if (metronome->setting_scroll) {
+        // Stop scroll.
+        metronome->setting_scroll = false;
+        movement_request_tick_frequency(4);
+    } else {
+        // Increment the digit being set, then recalculate the ticks for the new BPM.
+        setting_digit_inc(metronome);
+        metronome_ticks_calc(metronome);
     }
-    if (metronome->ticking) {
-        if (metronome->ticks_countdown)
-            metronome->ticks_countdown--;
-        if (metronome->ticks_countdown == 0) {
-            // A metronome beat has occurred.
-            // Reset the countdown.
-            metronome->ticks_countdown = metronome->ticks_calc;
-            // Update the remainder counter. If it overflows, increase the next countdown.
-            // This provides more accurate BPM on average, at the cost of some jitter in the short term.
-            metronome->ticks_count_remainder += metronome->ticks_calc_remainder;
-            if (metronome->ticks_count_remainder >= metronome->bpm) {
-                metronome->ticks_count_remainder -= metronome->bpm;
-                if (metronome->ticks_count_remainder >= metronome->bpm)
-                    metronome->ticks_count_remainder = 0;
-                metronome->ticks_countdown++;
-            }
-            // Display the tick or tock in the seconds position.
-            metronome->ticktock = !metronome->ticktock;
-            if (metronome->ticktock)
-                watch_display_text(WATCH_POSITION_SECONDS, "# ");
-            else
-                watch_display_text(WATCH_POSITION_SECONDS, " #");
-            // Beep if enabled.
-            if (metronome->beep)
-                watch_buzzer_play_note(BUZZER_NOTE_C8, 50);
-        }
+}
+
+static void setting_button_long_start_scroll(metronome_state_t *metronome) {
+    if (!metronome->setting_scroll) {
+        // Start to scroll the BPM number.
+        metronome->setting_scroll = true;
+        metronome->setting_flasher = false;
+        movement_request_tick_frequency(8);
     }
+}
+
+static void setting_button_long_up_stop_scroll(metronome_state_t *metronome) {
+    if (metronome->setting_scroll) {
+        // Stop scroll.
+        metronome->setting_scroll = false;
+        movement_request_tick_frequency(4);
+    }
+}
+
+static void setting_reset_default(metronome_state_t *metronome) {
+    // Reset to default BPM.
+    metronome->bpm = METRONOME_BPM_DEFAULT;
+    metronome_ticks_calc(metronome);
+    metronome->setting_item = 0;
+}
+
+static void setting_next(metronome_state_t *metronome) {
+    if (metronome->setting_item == 0) {
+        // Move to the ones digit of the BPM.
+        metronome->setting_item = 1;
+    } else {
+        // Exit setting mode, start ticking again.
+        setting_exit(metronome);
+    }
+}
+
+static void setting_tick(metronome_state_t *metronome) {
+    if (metronome->setting_scroll) {
+        if (HAL_GPIO_BTN_ALARM_read()) {
+            setting_digit_inc(metronome);
+            metronome_ticks_calc(metronome);
+        }
+    } else {
+        // Flash the item being set.
+        metronome->setting_flasher = !metronome->setting_flasher;
+    }
+    metronome_display_bpm(metronome);
 }
 
 void metronome_face_setup(uint8_t watch_face_index, void ** context_ptr) {
@@ -191,46 +272,22 @@ bool metronome_face_loop(movement_event_t event, void *context) {
     switch (event.event_type) {
         case EVENT_ALARM_BUTTON_UP:
             if (metronome->setting) {
-                if (metronome->setting_scroll) {
-                    metronome->setting_scroll = false;
-                    movement_request_tick_frequency(4);
-                } else {
-                    settings_increment(metronome);
-                    metronome_ticks_calc(metronome);
-                }
+                setting_button_up_inc(metronome);
             } else {
-                if (metronome->bpm < METRONOME_BPM_MAX) {
-                    metronome->bpm++;
-                    metronome_ticks_calc(metronome);
-                    metronome_display_bpm(metronome);
-                }
+                running_bpm_inc(metronome);
             }
             break;
         case EVENT_ALARM_LONG_UP:
             if (metronome->setting) {
-                if (metronome->setting_scroll) {
-                    metronome->setting_scroll = false;
-                    movement_request_tick_frequency(4);
-                }
+                setting_button_long_up_stop_scroll(metronome);
             }
             break;
         case EVENT_ALARM_LONG_PRESS:
             if (metronome->setting) {
-                if (!metronome->setting_scroll) {
-                    // Start to scroll the BPM number.
-                    metronome->setting_scroll = true;
-                    metronome->setting_flasher = false;
-                    movement_request_tick_frequency(8);
-                }
-                metronome->setting_scroll = true;
+                setting_button_long_start_scroll(metronome);
             } else {
-                // Entering setting mode, stop ticking and reset settings.
-                metronome->setting = true;
-                metronome->setting_flasher = false;
-                metronome->setting_scroll = false;
-                metronome->setting_item = 0;
-                metronome_stop_ticking(metronome);
-                movement_request_tick_frequency(4);
+                // Enter setting mode, stop ticking and reset settings.
+                setting_enter(metronome);
             }
             break;
         case EVENT_LIGHT_BUTTON_DOWN:
@@ -238,30 +295,14 @@ bool metronome_face_loop(movement_event_t event, void *context) {
             break;
         case EVENT_LIGHT_BUTTON_UP:
             if (metronome->setting) {
-                if (metronome->setting_item == 0) {
-                    // Move to the ones digit of the BPM.
-                    metronome->setting_item = 1;
-                } else {
-                    // Exit setting mode, start ticking again.
-                    metronome->setting = false;
-                    metronome_display_bpm(metronome);
-                    metronome_start_ticking(metronome);
-                }
+                setting_next(metronome);
             } else {
-                // Decrement the BPM.
-                if (metronome->bpm > METRONOME_BPM_MIN) {
-                    metronome->bpm--;
-                    metronome_ticks_calc(metronome);
-                    metronome_display_bpm(metronome);
-                }
+                running_bpm_dec(metronome);
             }
             break;
         case EVENT_LIGHT_LONG_PRESS:
             if (metronome->setting) {
-                // Reset to default BPM.
-                metronome->bpm = METRONOME_BPM_DEFAULT;
-                metronome_ticks_calc(metronome);
-                metronome->setting_item = 0;
+                setting_reset_default(metronome);
             } else {
                 // Toggle beep on/off.
                 metronome->beep = !metronome->beep;
@@ -269,7 +310,18 @@ bool metronome_face_loop(movement_event_t event, void *context) {
             }
             break;
         case EVENT_TICK:
-            metronome_tick(metronome);
+            if (metronome->setting) {
+                setting_tick(metronome);
+            }
+            if (metronome->ticking) {
+                running_tick(metronome);
+            }
+            break;
+        case EVENT_TIMEOUT:
+            if (metronome->setting) {
+                // Exit setting mode, start ticking again.
+                setting_exit(metronome);
+            }
             break;
         default:
             movement_default_loop_handler(event);

--- a/watch-faces/complication/metronome_face.c
+++ b/watch-faces/complication/metronome_face.c
@@ -31,12 +31,8 @@
 #include "watch.h"
 #include "watch_common_display.h"
 
-// tick frequency will be 2 to this power Hz (0 for 1 Hz, 2 for 4 Hz, etc.)
-#ifndef METRONOME_FACE_FREQUENCY_FACTOR
-#define METRONOME_FACE_FREQUENCY_FACTOR (6ul)
-#endif
-
-#define METRONOME_FACE_FREQUENCY (1 << METRONOME_FACE_FREQUENCY_FACTOR)
+// tick frequency must be a power of two, between 1 and 128 Hz.
+#define METRONOME_FACE_FREQUENCY (64u)
 
 #define METRONOME_BPM_DEFAULT (120u)
 #define METRONOME_BPM_MIN     (40u)
@@ -44,6 +40,8 @@
 
 typedef struct {
     bool ticking;
+    bool beep;
+    bool ticktock;
     uint8_t bpm;
     uint16_t ticks_calc;
     uint16_t ticks_calc_remainder;
@@ -62,10 +60,18 @@ static void metronome_display_bpm(metronome_state_t *metronome) {
     watch_display_text(WATCH_POSITION_BOTTOM, buf);
 }
 
+static void metronome_indicate_beep(metronome_state_t *metronome) {
+    if (metronome->beep) {
+        watch_set_indicator(WATCH_INDICATOR_BELL);
+    } else {
+        watch_clear_indicator(WATCH_INDICATOR_BELL);
+    }
+}
+
 static void metronome_ticks_calc(metronome_state_t *metronome) {
-    div_t result = div(METRONOME_FACE_FREQUENCY * 60, metronome->bpm);
-    metronome->ticks_calc = result.quot;
-    metronome->ticks_calc_remainder = result.rem;
+    uint16_t numerator = METRONOME_FACE_FREQUENCY * 60u;
+    metronome->ticks_calc = numerator / metronome->bpm;
+    metronome->ticks_calc_remainder = numerator % metronome->bpm;
 }
 
 static void metronome_start_ticking(metronome_state_t *metronome) {
@@ -95,7 +101,13 @@ static void metronome_tick(metronome_state_t *metronome) {
             }
             metronome->ticks_countdown++;
         }
-        watch_buzzer_play_note(BUZZER_NOTE_C8, 50);
+        metronome->ticktock = !metronome->ticktock;
+        if (metronome->ticktock)
+            watch_display_text(WATCH_POSITION_SECONDS, "# ");
+        else
+            watch_display_text(WATCH_POSITION_SECONDS, " #");
+        if (metronome->beep)
+            watch_buzzer_play_note(BUZZER_NOTE_C8, 50);
     }
 }
 
@@ -118,6 +130,7 @@ void metronome_face_activate(void *context) {
     metronome_state_t *metronome = context;
 
     metronome->ticking = false;
+    metronome->beep = false;
 
     if (metronome->bpm < METRONOME_BPM_MIN || metronome->bpm > METRONOME_BPM_MAX) {
         metronome->bpm = METRONOME_BPM_DEFAULT;
@@ -134,10 +147,7 @@ bool metronome_face_loop(movement_event_t event, void *context) {
     metronome_state_t *metronome = (metronome_state_t *) context;
 
     switch (event.event_type) {
-        case EVENT_ALARM_BUTTON_DOWN:
-            break;
         case EVENT_ALARM_BUTTON_UP:
-        case EVENT_ALARM_LONG_UP:
             if (metronome->bpm < METRONOME_BPM_MAX) {
                 metronome->bpm++;
                 metronome_ticks_calc(metronome);
@@ -148,18 +158,18 @@ bool metronome_face_loop(movement_event_t event, void *context) {
             // Inhibit the LED
             break;
         case EVENT_LIGHT_BUTTON_UP:
-        case EVENT_LIGHT_LONG_UP:
             if (metronome->bpm > METRONOME_BPM_MIN) {
                 metronome->bpm--;
                 metronome_ticks_calc(metronome);
                 metronome_display_bpm(metronome);
             }
             break;
+        case EVENT_LIGHT_LONG_PRESS:
+            metronome->beep = !metronome->beep;
+            metronome_indicate_beep(metronome);
+            break;
         case EVENT_TICK:
             metronome_tick(metronome);
-            break;
-        case EVENT_TIMEOUT:
-            movement_move_to_face(0);
             break;
         default:
             movement_default_loop_handler(event);

--- a/watch-faces/complication/metronome_face.c
+++ b/watch-faces/complication/metronome_face.c
@@ -47,10 +47,11 @@ typedef struct {
     bool setting_flasher;
     uint8_t setting_item;
     uint8_t bpm;
-    uint16_t ticks_calc;
-    uint16_t ticks_calc_remainder;
-    uint16_t ticks_countdown;
-    uint16_t ticks_count_remainder;
+
+    rtc_counter_t counter_calc;
+    uint16_t counter_calc_remainder;
+    rtc_counter_t counter_next;
+    uint16_t counter_remainder;
 } metronome_state_t;
 
 static void metronome_display_title(metronome_state_t *metronome) {
@@ -80,16 +81,18 @@ static void metronome_indicate_beep(metronome_state_t *metronome) {
     }
 }
 
-static void metronome_ticks_calc(metronome_state_t *metronome) {
-    uint16_t numerator = METRONOME_FACE_FREQUENCY * 60u;
-    metronome->ticks_calc = numerator / metronome->bpm;
-    metronome->ticks_calc_remainder = numerator % metronome->bpm;
+static void metronome_counter_calc(metronome_state_t *metronome) {
+    uint16_t numerator = watch_rtc_get_frequency() * 60u;
+    metronome->counter_calc = numerator / metronome->bpm;
+    metronome->counter_calc_remainder = numerator % metronome->bpm;
 }
 
 static void metronome_start_ticking(metronome_state_t *metronome) {
     metronome->ticking = true;
-    metronome->ticks_countdown = 1;
-    metronome->ticks_count_remainder = 0;
+
+    metronome->counter_next = watch_rtc_get_counter() + 8u;
+    metronome->counter_remainder = 0;
+
     movement_request_tick_frequency(METRONOME_FACE_FREQUENCY);
 }
 
@@ -100,27 +103,36 @@ static void metronome_stop_ticking(metronome_state_t *metronome) {
 
 // Tick handler while metronome->ticking is true.
 static void running_tick(metronome_state_t *metronome) {
-    if (metronome->ticks_countdown)
-        metronome->ticks_countdown--;
-    if (metronome->ticks_countdown == 0) {
+    uint32_t counter = watch_rtc_get_counter();
+    if ((counter - metronome->counter_next) < 0x80000000u) {
         // A metronome beat has occurred.
-        // Reset the countdown.
-        metronome->ticks_countdown = metronome->ticks_calc;
+        // Set new counter_next.
+        metronome->counter_next += metronome->counter_calc;
+#if __EMSCRIPTEN__
+    if ((counter - metronome->counter_next) < 0x80000000u) {
+        // If the counter_next is still in the past, we must have missed a beat.
+        // This can happen if the browser stops running the simulation for a while, eg if the tab is in the background.
+        // In this case, we will skip to the next beat.
+        metronome->counter_next = counter + metronome->counter_calc;
+    }
+#endif
         // Update the remainder counter. If it overflows, increase the next countdown.
         // This provides more accurate BPM on average, at the cost of some jitter in the short term.
-        metronome->ticks_count_remainder += metronome->ticks_calc_remainder;
-        if (metronome->ticks_count_remainder >= metronome->bpm) {
-            metronome->ticks_count_remainder -= metronome->bpm;
-            if (metronome->ticks_count_remainder >= metronome->bpm)
-                metronome->ticks_count_remainder = 0;
-            metronome->ticks_countdown++;
+        metronome->counter_remainder += metronome->counter_calc_remainder;
+        if (metronome->counter_remainder >= metronome->bpm) {
+            metronome->counter_remainder -= metronome->bpm;
+            if (metronome->counter_remainder >= metronome->bpm)
+                metronome->counter_remainder = 0;
+            metronome->counter_next++;
         }
+
         // Display the tick or tock in the seconds position.
         metronome->ticktock = !metronome->ticktock;
         if (metronome->ticktock)
             watch_display_text(WATCH_POSITION_SECONDS, "# ");
         else
             watch_display_text(WATCH_POSITION_SECONDS, " #");
+
         // Beep if enabled.
         if (metronome->beep)
             watch_buzzer_play_note(BUZZER_NOTE_C8, 50);
@@ -131,7 +143,7 @@ static void running_tick(metronome_state_t *metronome) {
 static void running_bpm_inc(metronome_state_t *metronome) {
     if (metronome->bpm < METRONOME_BPM_MAX) {
         metronome->bpm++;
-        metronome_ticks_calc(metronome);
+        metronome_counter_calc(metronome);
         metronome_display_bpm(metronome);
     }
 }
@@ -140,7 +152,7 @@ static void running_bpm_inc(metronome_state_t *metronome) {
 static void running_bpm_dec(metronome_state_t *metronome) {
     if (metronome->bpm > METRONOME_BPM_MIN) {
         metronome->bpm--;
-        metronome_ticks_calc(metronome);
+        metronome_counter_calc(metronome);
         metronome_display_bpm(metronome);
     }
 }
@@ -183,7 +195,7 @@ static void setting_button_up_inc(metronome_state_t *metronome) {
     } else {
         // Increment the digit being set, then recalculate the ticks for the new BPM.
         setting_digit_inc(metronome);
-        metronome_ticks_calc(metronome);
+        metronome_counter_calc(metronome);
     }
 }
 
@@ -207,7 +219,7 @@ static void setting_button_long_up_stop_scroll(metronome_state_t *metronome) {
 static void setting_reset_default(metronome_state_t *metronome) {
     // Reset to default BPM.
     metronome->bpm = METRONOME_BPM_DEFAULT;
-    metronome_ticks_calc(metronome);
+    metronome_counter_calc(metronome);
     metronome->setting_item = 0;
 }
 
@@ -225,7 +237,7 @@ static void setting_tick(metronome_state_t *metronome) {
     if (metronome->setting_scroll) {
         if (HAL_GPIO_BTN_ALARM_read()) {
             setting_digit_inc(metronome);
-            metronome_ticks_calc(metronome);
+            metronome_counter_calc(metronome);
         }
     } else {
         // Flash the item being set.
@@ -243,7 +255,7 @@ void metronome_face_setup(uint8_t watch_face_index, void ** context_ptr) {
         memset(metronome, 0, sizeof(metronome_state_t));
 
         metronome->bpm = METRONOME_BPM_DEFAULT;
-        metronome_ticks_calc(metronome);
+        metronome_counter_calc(metronome);
 
         *context_ptr = metronome;
     }
@@ -259,7 +271,7 @@ void metronome_face_activate(void *context) {
     if (metronome->bpm < METRONOME_BPM_MIN || metronome->bpm > METRONOME_BPM_MAX) {
         metronome->bpm = METRONOME_BPM_DEFAULT;
     }
-    metronome_ticks_calc(metronome);
+    metronome_counter_calc(metronome);
 
     metronome_start_ticking(metronome);
 

--- a/watch-faces/complication/metronome_face.c
+++ b/watch-faces/complication/metronome_face.c
@@ -1,0 +1,176 @@
+/* SPDX-License-Identifier: MIT */
+
+/*
+ * MIT License
+ *
+ * Copyright © 2026 Craig McQueen <craig@mcqueen.au>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "metronome_face.h"
+#include "watch.h"
+#include "watch_common_display.h"
+
+// tick frequency will be 2 to this power Hz (0 for 1 Hz, 2 for 4 Hz, etc.)
+#ifndef METRONOME_FACE_FREQUENCY_FACTOR
+#define METRONOME_FACE_FREQUENCY_FACTOR (6ul)
+#endif
+
+#define METRONOME_FACE_FREQUENCY (1 << METRONOME_FACE_FREQUENCY_FACTOR)
+
+#define METRONOME_BPM_DEFAULT (120u)
+#define METRONOME_BPM_MIN     (40u)
+#define METRONOME_BPM_MAX     (180u)
+
+typedef struct {
+    bool ticking;
+    uint8_t bpm;
+    uint16_t ticks_calc;
+    uint16_t ticks_calc_remainder;
+    uint16_t ticks_countdown;
+    uint16_t ticks_count_remainder;
+} metronome_state_t;
+
+static void metronome_display_title(metronome_state_t *metronome) {
+    (void) metronome;
+    watch_display_text_with_fallback(WATCH_POSITION_TOP, "METRO", "ME");
+}
+
+static void metronome_display_bpm(metronome_state_t *metronome) {
+    char buf[7];
+    snprintf(buf, sizeof(buf), "%3u", metronome->bpm);
+    watch_display_text(WATCH_POSITION_BOTTOM, buf);
+}
+
+static void metronome_ticks_calc(metronome_state_t *metronome) {
+    div_t result = div(METRONOME_FACE_FREQUENCY * 60, metronome->bpm);
+    metronome->ticks_calc = result.quot;
+    metronome->ticks_calc_remainder = result.rem;
+}
+
+static void metronome_start_ticking(metronome_state_t *metronome) {
+    metronome->ticking = true;
+    metronome->ticks_countdown = 1;
+    metronome->ticks_count_remainder = 0;
+    movement_request_tick_frequency(METRONOME_FACE_FREQUENCY);
+}
+
+static void metronome_stop_ticking(metronome_state_t *metronome) {
+    movement_request_tick_frequency(1);
+    metronome->ticking = false;
+}
+
+static void metronome_tick(metronome_state_t *metronome) {
+    if (!metronome->ticking) { return; }
+
+    if (metronome->ticks_countdown)
+        metronome->ticks_countdown--;
+    if (metronome->ticks_countdown == 0) {
+        metronome->ticks_countdown = metronome->ticks_calc;
+        metronome->ticks_count_remainder += metronome->ticks_calc_remainder;
+        if (metronome->ticks_count_remainder >= metronome->bpm) {
+            metronome->ticks_count_remainder -= metronome->bpm;
+            if (metronome->ticks_count_remainder >= metronome->bpm) {
+                metronome->ticks_count_remainder = 0;
+            }
+            metronome->ticks_countdown++;
+        }
+        watch_buzzer_play_note(BUZZER_NOTE_C8, 50);
+    }
+}
+
+void metronome_face_setup(uint8_t watch_face_index, void ** context_ptr) {
+    (void) watch_face_index;
+
+    if (*context_ptr == NULL) {
+        metronome_state_t *metronome = malloc(sizeof(metronome_state_t));
+
+        memset(metronome, 0, sizeof(metronome_state_t));
+
+        metronome->bpm = METRONOME_BPM_DEFAULT;
+        metronome_ticks_calc(metronome);
+
+        *context_ptr = metronome;
+    }
+}
+
+void metronome_face_activate(void *context) {
+    metronome_state_t *metronome = context;
+
+    metronome->ticking = false;
+
+    if (metronome->bpm < METRONOME_BPM_MIN || metronome->bpm > METRONOME_BPM_MAX) {
+        metronome->bpm = METRONOME_BPM_DEFAULT;
+    }
+    metronome_ticks_calc(metronome);
+
+    metronome_start_ticking(metronome);
+
+    metronome_display_title(metronome);
+    metronome_display_bpm(metronome);
+}
+
+bool metronome_face_loop(movement_event_t event, void *context) {
+    metronome_state_t *metronome = (metronome_state_t *) context;
+
+    switch (event.event_type) {
+        case EVENT_ALARM_BUTTON_DOWN:
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+        case EVENT_ALARM_LONG_UP:
+            if (metronome->bpm < METRONOME_BPM_MAX) {
+                metronome->bpm++;
+                metronome_ticks_calc(metronome);
+                metronome_display_bpm(metronome);
+            }
+            break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            // Inhibit the LED
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+        case EVENT_LIGHT_LONG_UP:
+            if (metronome->bpm > METRONOME_BPM_MIN) {
+                metronome->bpm--;
+                metronome_ticks_calc(metronome);
+                metronome_display_bpm(metronome);
+            }
+            break;
+        case EVENT_TICK:
+            metronome_tick(metronome);
+            break;
+        case EVENT_TIMEOUT:
+            movement_move_to_face(0);
+            break;
+        default:
+            movement_default_loop_handler(event);
+            break;
+    }
+
+    return true;
+}
+
+void metronome_face_resign(void *context) {
+    metronome_state_t *metronome = (metronome_state_t *) context;
+
+    metronome_stop_ticking(metronome);
+}

--- a/watch-faces/complication/metronome_face.h
+++ b/watch-faces/complication/metronome_face.h
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: MIT */
+
+/*
+ * MIT License
+ *
+ * Copyright © 2021-2022 Joey Castillo <joeycastillo@utexas.edu> <jose.castillo@gmail.com>
+ * Copyright © 2022 Alexsander Akers <me@a2.io>
+ * Copyright © 2023 Alex Utter <ooterness@gmail.com>
+ * Copyright © 2024 Matheus Afonso Martins Moreira <matheus.a.m.moreira@gmail.com> (https://www.matheusmoreira.com/)
+ * Copyright © 2026 Craig McQueen <craig@mcqueen.au>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef METRONOME_FACE_H
+#define METRONOME_FACE_H
+
+/*
+ * METRONOME face
+ *
+ * The metronome implements a musical metronome, to tick at a specified tempo in beats per minute
+ * (BPM). The user can adjust the tempo between 40 and 180 BPM. The default tempo is 120 BPM.
+ */
+
+#include "movement.h"
+
+void metronome_face_setup(uint8_t watch_face_index, void ** context_ptr);
+void metronome_face_activate(void *context);
+bool metronome_face_loop(movement_event_t event,void *context);
+void metronome_face_resign(void *context);
+
+#define metronome_face ((const watch_face_t){ \
+    metronome_face_setup, \
+    metronome_face_activate, \
+    metronome_face_loop, \
+    metronome_face_resign, \
+    NULL, \
+})
+
+#endif // METRONOME_FACE_H


### PR DESCRIPTION
This is a new and different implementation compared to the legacy metronome implementation.

I'm open to suggestions for improvements and changes.

It uses `watch_rtc_get_counter()` for timing of metronome ticks. This allows for decent timing accuracy in the simulator. (In the simulator I have found that 64 and 128 Hz tick frequency doesn't produce `EVENT_TICK` at the specified frequency, apparently due to the main loop running at a slower rate. See issue #222.)

The beat is indicated visually by tocking circles in the seconds digits. A long press of LIGHT button enables audible beeps.

ALARM button increments the bpm. LIGHT button decrements the bpm.

A long press of ALARM button goes into setting mode, where the bpm can be set to any value from 40 to 209.

Internally, this uses the 128 Hz running counter. It counts fractions of the calculated tick period to jitter the period to maintain an accurate average bpm.