### PR TITLE
Fix of two bugs in deadline face

### DIFF
--- a/watch-faces/complication/deadline_face.c
+++ b/watch-faces/complication/deadline_face.c
@@ -227,7 +227,7 @@ static void _correct_time_difference(int16_t *units, watch_date_time_t deadline)
 /* Increment date in settings mode. Function taken from `set_time_face.c` */
 static void _increment_date(deadline_state_t *state, watch_date_time_t date_time)
 {
-    const uint8_t days_in_month[12] = { 31, 28, 31, 30, 31, 30, 30, 31, 30, 31, 30, 31 };
+    const uint8_t days_in_month[12] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
     switch (state->current_page) {
         case 0:

--- a/watch-faces/complication/deadline_face.c
+++ b/watch-faces/complication/deadline_face.c
@@ -237,17 +237,18 @@ static void _increment_date(deadline_state_t *state, watch_date_time_t date_time
         case 1:
             date_time.unit.month = (date_time.unit.month % 12) + 1;
             break;
-        case 2:
-            date_time.unit.day = date_time.unit.day + 1;
-
+        case 2: {
             /* Check for leap years */
-            int8_t days = days_in_month[date_time.unit.month - 1];
+            uint8_t days = days_in_month[date_time.unit.month - 1];
             if (date_time.unit.month == 2 && _is_leap(date_time.unit.year))
                 days++;
 
-            if (date_time.unit.day > days)
-                date_time.unit.day = 1;
+            /* Compute next day outside the 5-bit bitfield so overflow past 31
+             * can be compared against `days` before it gets truncated. */
+            uint8_t day = date_time.unit.day + 1;
+            date_time.unit.day = (day > days) ? 1 : day;
             break;
+        }
         case 3:
             date_time.unit.hour = (date_time.unit.hour + 1) % 24;
             break;

--- a/watch-faces/complication/deadline_face.c
+++ b/watch-faces/complication/deadline_face.c
@@ -227,8 +227,6 @@ static void _correct_time_difference(int16_t *units, watch_date_time_t deadline)
 /* Increment date in settings mode. Function taken from `set_time_face.c` */
 static void _increment_date(deadline_state_t *state, watch_date_time_t date_time)
 {
-    const uint8_t days_in_month[12] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
-
     switch (state->current_page) {
         case 0:
             /* Only 10 years covered. Fix this sometime next decade */
@@ -238,10 +236,7 @@ static void _increment_date(deadline_state_t *state, watch_date_time_t date_time
             date_time.unit.month = (date_time.unit.month % 12) + 1;
             break;
         case 2: {
-            /* Check for leap years */
-            uint8_t days = days_in_month[date_time.unit.month - 1];
-            if (date_time.unit.month == 2 && _is_leap(date_time.unit.year))
-                days++;
+            int days = _days_in_month(date_time.unit.month, date_time.unit.year);
 
             /* Compute next day outside the 5-bit bitfield so overflow past 31
              * can be compared against `days` before it gets truncated. */


### PR DESCRIPTION
## Summary
- Fixed a wrong day count for July (30 instead of 31) in a local month-length table inside `_increment_date()`, which made July 31 unreachable when setting a deadline.
- Fixed the actual root-cause bug behind date corruption when incrementing past the last day of a month: `date_time.unit.day` is a 5-bit bitfield (max 31), so incrementing 31 -> 32 silently truncated to 0 *before* the overflow bounds-check could catch it, which then decoded as the last day of the *previous* month (e.g. Aug 31 -> Jul 31 -> Jun 30 when repeatedly incrementing the day).
- Removed the now-redundant local month-length table in `_increment_date()` in favor of the existing `_days_in_month()` helper, since the file had two independent copies of the same table and that duplication is how the July typo went unnoticed in the first place.