### PR TITLE
Fix two bugs in lis2dw_monitor_face

### DIFF
--- a/watch-faces/sensor/lis2dw_monitor_face.c
+++ b/watch-faces/sensor/lis2dw_monitor_face.c
@@ -31,9 +31,6 @@
 /* Display frequency */
 #define DISPLAY_FREQUENCY 8
 
-/* Settings */
-#define NUM_SETTINGS 7
-
 static void _settings_title_display(lis2dw_monitor_state_t *state, char *buf1, char *buf2)
 {
     char buf[10];
@@ -541,7 +538,6 @@ void lis2dw_monitor_face_setup(uint8_t watch_face_index, void **context_ptr)
 
     /* Initialize settings */
     uint8_t settings_page = 0;
-    state->settings = malloc(NUM_SETTINGS * sizeof(lis2dw_settings_t));
     state->settings[settings_page].display = _settings_mode_display;
     state->settings[settings_page].advance = _settings_mode_advance;
     settings_page++;

--- a/watch-faces/sensor/lis2dw_monitor_face.c
+++ b/watch-faces/sensor/lis2dw_monitor_face.c
@@ -384,7 +384,7 @@ static void _monitor_display(lis2dw_monitor_state_t *state)
 {
     char buf[10];
 
-    snprintf(buf, sizeof(buf), " %C ", "XYZ"[state->axis]);
+    snprintf(buf, sizeof(buf), " %c ", "XYZ"[state->axis]);
     watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, buf, buf);
 
     snprintf(buf, sizeof(buf), "%2d", state->axis + 1);

--- a/watch-faces/sensor/lis2dw_monitor_face.h
+++ b/watch-faces/sensor/lis2dw_monitor_face.h
@@ -56,13 +56,16 @@ typedef struct {
     void (*advance)(void *);
 } lis2dw_settings_t;
 
+/* Number of settings pages */
+#define NUM_SETTINGS 7
+
 typedef struct {
     uint8_t axis:2;             /* Axis to display */
     lis2dw_reading_t reading;   /* Current reading */
     lis2dw_monitor_page_t page; /* Displayed page */
     lis2dw_device_state_t ds;   /* Device state */
     uint8_t settings_page:3;    /* Subpage in settings */
-    lis2dw_settings_t *settings;        /* Settings config */
+    lis2dw_settings_t settings[NUM_SETTINGS]; /* Settings config */
     uint8_t show_title:6;       /* Display face title */
 } lis2dw_monitor_state_t;
 


### PR DESCRIPTION
## Summary
- Fixed a memory leak: `state->settings` was malloc'd in `lis2dw_monitor_face_setup()` outside the guard that only runs on first allocation of the face's context. `setup()` is called again every time the watch wakes from sleep (per `movement.h`'s own documentation on `watch_face_setup`), so each wake cycle allocated a new settings array and abandoned the previous pointer with no matching free. Fixed by making `settings` a fixed-size array embedded directly in `lis2dw_monitor_state_t` instead of a separately malloc'd pointer, since `NUM_SETTINGS` is a compile-time constant.
- Fixed a wrong format specifier: `_monitor_display()` used `%C` (wide character, expects `wint_t`) instead of `%c` (plain `char`/`int`) to print the X/Y/Z axis label. Every other single-character display in the codebase uses `%c`.