### PR TITLE
feat: Wake on motion

### DIFF
--- a/movement.c
+++ b/movement.c
@@ -1167,14 +1167,14 @@ void app_setup(void) {
             // next: INT2 is wired to pin A4. We'll configure the accelerometer to output the sleep state on INT2.
             // a falling edge on INT2 indicates the accelerometer has woken up.
             lis2dw_configure_int2(LIS2DW_CTRL5_INT2_SLEEP_STATE | LIS2DW_CTRL5_INT2_SLEEP_CHG);
-            HAL_GPIO_A4_in();
 
-            // Wake on motion: a falling edge on A4 (accelerometer stationary->moving) wakes the watch
-            // and resets the LE inactivity countdown via cb_accelerometer_wake().
-            // This uses the SLEEP_CHG transition interrupt configured above, so sustained motion
-            // produces one wake edge only, not a continuous interrupt stream. Going back to sleep is
-            // left to the normal LE inactivity timeout.
-            watch_register_extwake_callback(HAL_GPIO_A4_pin(), cb_accelerometer_wake, false);
+            // wake on motion: A4 is armed as an extwake source at sleep entry (see app_loop)
+            // and disarmed here on wake, so while awake nothing monitors it.
+            if (movement_state.wake_on_motion) {
+                watch_disable_extwake_interrupt(HAL_GPIO_A4_pin());
+            } else {
+                HAL_GPIO_A4_in();
+            }
 
             // later on, we are going to use INT1 for tap detection. We'll set up that interrupt here,
             // but it will only fire once tap recognition is enabled.
@@ -1248,6 +1248,13 @@ static void _sleep_mode_app_loop(void) {
 }
 
 #endif
+
+// True if wake-on-motion is active and the accelerometer currently reports motion.
+static bool _movement_accelerometer_in_motion(void) {
+    if (!movement_state.wake_on_motion || !movement_state.has_lis2dw) return false;
+    if (movement_state.accelerometer_background_rate == LIS2DW_DATA_RATE_POWERDOWN) return false;
+    return !(lis2dw_get_wakeup_source() & LIS2DW_WAKEUP_SRC_SLEEP_STATE);
+}
 
 static bool _switch_face(void) {
     const watch_face_t *wf = &watch_faces[movement_state.current_face_idx];
@@ -1368,6 +1375,14 @@ bool app_loop(void) {
     }
 
 #ifndef MOVEMENT_LOW_ENERGY_MODE_FORBIDDEN
+    // Wake-on-motion: if the countdown expired but the accelerometer still reports
+    // motion, restart the countdown and stay awake instead of sleeping.
+    if (movement_volatile_state.enter_sleep_mode && !movement_volatile_state.is_buzzing &&
+        _movement_accelerometer_in_motion()) {
+        movement_volatile_state.enter_sleep_mode = false;
+        _movement_reset_inactivity_countdown();
+    }
+
     // if we have timed out of our low energy mode countdown, enter low energy mode.
     if (movement_volatile_state.enter_sleep_mode && !movement_volatile_state.is_buzzing) {
         movement_volatile_state.enter_sleep_mode = false;
@@ -1377,6 +1392,20 @@ bool app_loop(void) {
         _movement_disable_inactivity_countdown();
 
         watch_register_extwake_callback(HAL_GPIO_BTN_ALARM_pin(), cb_alarm_btn_extwake, true);
+
+        if (movement_state.wake_on_motion && movement_state.has_lis2dw) {
+            // Configure the accelerometer directly. On wake, app_setup restores the original values from movement_state
+            lis2dw_set_data_rate(LIS2DW_DATA_RATE_LOWEST);
+            lis2dw_configure_wakeup_threshold(MOVEMENT_WAKE_ON_MOTION_THRESHOLD);
+
+            // Let the accelerometer settle after reconfiguration before arming the edge-triggered A4
+            // extwake source. Without this delay the wake-up condition is still asserted when we arm,
+            // so real motion produces no fresh edge and the watch never wakes.
+            delay_ms(50);
+
+            // Arm A4 as an extwake source so motion wakes the watch from sleep.
+            watch_register_extwake_callback(HAL_GPIO_A4_pin(), cb_accelerometer_wake, false);
+        }
 
         // _sleep_mode_app_loop takes over at this point and loops until exit_sleep_mode is set by the extwake handler,
         // or wake is requested using the movement_request_wake function.
@@ -1581,14 +1610,6 @@ void cb_accelerometer_event(void) {
 
 void cb_accelerometer_wake(void) {
     movement_volatile_state.pending_events |= 1 << EVENT_ACCELEROMETER_WAKE;
-
     if (!movement_state.wake_on_motion) return;
-
-    // Only request a full wake while actually in low-energy sleep; doing it while
-    // awake would latch exit_sleep_mode and abort the next sleep entry.
-    if (movement_volatile_state.is_sleeping) {
-        movement_request_wake();
-    } else {
-        _movement_reset_inactivity_countdown();
-    }
+    movement_request_wake();
 }

--- a/movement.c
+++ b/movement.c
@@ -1253,7 +1253,7 @@ static void _sleep_mode_app_loop(void) {
 static bool _movement_accelerometer_in_motion(void) {
     if (!movement_state.wake_on_motion || !movement_state.has_lis2dw) return false;
     if (movement_state.accelerometer_background_rate == LIS2DW_DATA_RATE_POWERDOWN) return false;
-    return !(lis2dw_get_wakeup_source() & LIS2DW_WAKEUP_SRC_SLEEP_STATE);
+    return !HAL_GPIO_A4_read();
 }
 
 static bool _switch_face(void) {

--- a/movement.c
+++ b/movement.c
@@ -928,6 +928,14 @@ bool movement_set_accelerometer_motion_threshold(uint8_t new_threshold) {
     return false;
 }
 
+bool movement_get_wake_on_motion(void) {
+    return movement_state.wake_on_motion;
+}
+
+void movement_set_wake_on_motion(bool value) {
+    movement_state.wake_on_motion = value;
+}
+
 float movement_get_temperature(void) {
     float temperature_c = (float)0xFFFFFFFF;
 #if __EMSCRIPTEN__
@@ -1064,6 +1072,11 @@ void app_init(void) {
 
     if (movement_state.accelerometer_motion_threshold == 0) movement_state.accelerometer_motion_threshold = 32;
 
+    // support for wake on motion. if enabled motion will wake the watch from
+    // low-energy mode. this feature is off by default but can be enabled from the
+    // accelerometer status face.
+    movement_state.wake_on_motion = false;
+
     movement_state.signal_volume = MOVEMENT_DEFAULT_SIGNAL_VOLUME;
     movement_state.alarm_volume = MOVEMENT_DEFAULT_ALARM_VOLUME;
     movement_state.light_on = false;
@@ -1156,9 +1169,12 @@ void app_setup(void) {
             lis2dw_configure_int2(LIS2DW_CTRL5_INT2_SLEEP_STATE | LIS2DW_CTRL5_INT2_SLEEP_CHG);
             HAL_GPIO_A4_in();
 
-            // Wake on motion seemed like a good idea when the threshold was lower, but the UX makes less sense now.
-            // Still if you want to wake on motion, you can do it by uncommenting this line:
-            // watch_register_extwake_callback(HAL_GPIO_A4_pin(), cb_accelerometer_wake, false);
+            // Wake on motion: a falling edge on A4 (accelerometer stationary->moving) wakes the watch
+            // and resets the LE inactivity countdown via cb_accelerometer_wake().
+            // This uses the SLEEP_CHG transition interrupt configured above, so sustained motion
+            // produces one wake edge only, not a continuous interrupt stream. Going back to sleep is
+            // left to the normal LE inactivity timeout.
+            watch_register_extwake_callback(HAL_GPIO_A4_pin(), cb_accelerometer_wake, false);
 
             // later on, we are going to use INT1 for tap detection. We'll set up that interrupt here,
             // but it will only fire once tap recognition is enabled.
@@ -1565,6 +1581,14 @@ void cb_accelerometer_event(void) {
 
 void cb_accelerometer_wake(void) {
     movement_volatile_state.pending_events |= 1 << EVENT_ACCELEROMETER_WAKE;
-    // also: wake up!
-    _movement_reset_inactivity_countdown();
+
+    if (!movement_state.wake_on_motion) return;
+
+    // Only request a full wake while actually in low-energy sleep; doing it while
+    // awake would latch exit_sleep_mode and abort the next sleep entry.
+    if (movement_volatile_state.is_sleeping) {
+        movement_request_wake();
+    } else {
+        _movement_reset_inactivity_countdown();
+    }
 }

--- a/movement.h
+++ b/movement.h
@@ -408,6 +408,8 @@ bool movement_set_accelerometer_background_rate(lis2dw_data_rate_t new_rate);
 uint8_t movement_get_accelerometer_motion_threshold(void);
 bool movement_set_accelerometer_motion_threshold(uint8_t new_threshold);
 
+#define MOVEMENT_HAS_WAKE_ON_MOTION
+
 // gets and sets the wake on motion feature
 bool movement_get_wake_on_motion(void);
 void movement_set_wake_on_motion(bool value);

--- a/movement.h
+++ b/movement.h
@@ -84,7 +84,7 @@ typedef union {
         // altimeter to display feet or meters as easily as it tells a thermometer to display degrees in F or C.
         bool clock_mode_24h : 1;            // indicates whether clock should use 12 or 24 hour mode.
         bool use_imperial_units : 1;        // indicates whether to use metric units (the default) or imperial.
-        
+
         bool button_volume : 1;             // 0 for soft beep, 1 for loud beep. If button_should_sound (above) is false, this is ignored.
     } bit;
     uint32_t reg;
@@ -299,6 +299,8 @@ typedef struct {
     lis2dw_data_rate_t accelerometer_background_rate;
     // threshold for considering the wearer is in motion
     uint8_t accelerometer_motion_threshold;
+    // wake on motion from low-energy mode
+    bool wake_on_motion;
 
     // signal and alarm volumes
     watch_buzzer_volume_t signal_volume;
@@ -405,6 +407,10 @@ bool movement_set_accelerometer_background_rate(lis2dw_data_rate_t new_rate);
 // gets and sets the accelerometer motion threshold
 uint8_t movement_get_accelerometer_motion_threshold(void);
 bool movement_set_accelerometer_motion_threshold(uint8_t new_threshold);
+
+// gets and sets the wake on motion feature
+bool movement_get_wake_on_motion(void);
+void movement_set_wake_on_motion(bool value);
 
 // If the board has a temperature sensor, this function will give you the temperature in degrees celsius.
 // If the board has multiple temperature sensors, it will use the most accurate one available.

--- a/movement_config.h
+++ b/movement_config.h
@@ -93,6 +93,12 @@ const watch_face_t watch_faces[] = {
  */
 #define MOVEMENT_DEFAULT_LOW_ENERGY_INTERVAL 2
 
+/* Motion sensitivity used to wake the watch from low energy mode when
+ * wake-on-motion is enabled. The value is in wake-up threshold steps of
+ * (2g / 64), so 8 corresponds to roughly 0.25 g.
+ */
+#define MOVEMENT_WAKE_ON_MOTION_THRESHOLD 8
+
 /* Set the led duration
  * Valid values are:
  * 0: No LED

--- a/watch-faces/sensor/accelerometer_status_face.c
+++ b/watch-faces/sensor/accelerometer_status_face.c
@@ -28,19 +28,6 @@
 #include "lis2dw.h"
 #include "watch.h"
 
-/* Default motion threshold: 16 = 0.5 G at +/-2g.
-   This is lower than the default 1G used in movement core because it should
-   track general motion and not just taps on the watch */
-#define ACCEL_DEFAULT_THRESHOLD 16
-
-/* Settings pages */
-typedef enum {
-    ACCEL_SETTING_THRESHOLD = 0,
-    ACCEL_SETTING_WAKE,
-} accel_setting_t;
-
-#define ACCEL_NUM_SETTINGS (ACCEL_SETTING_WAKE + 1)
-
 static void _status_display(void) {
     watch_display_text_with_fallback(WATCH_POSITION_TOP, "ACCEL", "AC");
     watch_set_indicator(WATCH_INDICATOR_SIGNAL);
@@ -48,15 +35,6 @@ static void _status_display(void) {
     // the motion pin reads HIGH when still at rest, LOW when active
     if (HAL_GPIO_A4_read()) watch_display_text(WATCH_POSITION_BOTTOM, "Still ");
     else watch_display_text_with_fallback(WATCH_POSITION_BOTTOM, "Active", " ACtiv");
-}
-
-static void _settings_title(accel_interrupt_count_state_t *state, const char *primary, const char *fallback) {
-    watch_display_text_with_fallback(WATCH_POSITION_TOP, primary, fallback);
-    if (watch_get_lcd_type() != WATCH_LCD_TYPE_CUSTOM) {
-        char buf[4];
-        snprintf(buf, sizeof(buf), "%2d", state->settings_page + 1);
-        watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
-    }
 }
 
 static bool _settings_blink(uint8_t subsecond) {
@@ -68,35 +46,12 @@ static bool _settings_blink(uint8_t subsecond) {
     return false;
 }
 
-static void _settings_display(accel_interrupt_count_state_t *state, uint8_t subsecond) {
+static void _settings_display(uint8_t subsecond) {
     watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
-
-    switch (state->settings_page) {
-        case ACCEL_SETTING_THRESHOLD:
-            _settings_title(state, "THRSH", "TH");
-            if (_settings_blink(subsecond)) return;
-            watch_display_float_with_best_effort(state->new_threshold * 0.03125f, " G");
-            break;
-        case ACCEL_SETTING_WAKE:
-            _settings_title(state, "WAKE ", "WA");
-            if (_settings_blink(subsecond)) return;
-            watch_clear_decimal_if_available();
-            watch_display_text(WATCH_POSITION_BOTTOM, movement_get_wake_on_motion() ? "  on  " : "  off ");
-            break;
-    }
-}
-
-static void _settings_advance(accel_interrupt_count_state_t *state) {
-    switch (state->settings_page) {
-        case ACCEL_SETTING_THRESHOLD:
-            state->new_threshold = (state->new_threshold + 1) % 64;
-            movement_set_accelerometer_motion_threshold(state->new_threshold);
-            state->threshold = state->new_threshold;
-            break;
-        case ACCEL_SETTING_WAKE:
-            movement_set_wake_on_motion(!movement_get_wake_on_motion());
-            break;
-    }
+    watch_display_text_with_fallback(WATCH_POSITION_TOP, "WAKE ", "WA");
+    if (_settings_blink(subsecond)) return;
+    watch_clear_decimal_if_available();
+    watch_display_text(WATCH_POSITION_BOTTOM, movement_get_wake_on_motion() ? "  on  " : "  off ");
 }
 
 void accelerometer_status_face_setup(uint8_t watch_face_index, void ** context_ptr) {
@@ -107,7 +62,6 @@ void accelerometer_status_face_setup(uint8_t watch_face_index, void ** context_p
 
         /* Set up accelerometer and enable background sensing */
         movement_set_accelerometer_background_rate(LIS2DW_DATA_RATE_LOWEST);
-        movement_set_accelerometer_motion_threshold(ACCEL_DEFAULT_THRESHOLD);
     }
 }
 
@@ -115,11 +69,8 @@ void accelerometer_status_face_activate(void *context) {
     accel_interrupt_count_state_t *state = (accel_interrupt_count_state_t *)context;
 
     state->is_setting = false;
-    state->settings_page = 0;
 
     movement_request_tick_frequency(4);
-
-    state->threshold = movement_get_accelerometer_motion_threshold();
 }
 
 bool accelerometer_status_face_loop(movement_event_t event, void *context) {
@@ -129,15 +80,11 @@ bool accelerometer_status_face_loop(movement_event_t event, void *context) {
         switch (event.event_type) {
             case EVENT_ACTIVATE:
             case EVENT_TICK:
-                _settings_display(state, event.subsecond);
-                break;
-            case EVENT_LIGHT_BUTTON_UP:
-                state->settings_page = (state->settings_page + 1) % ACCEL_NUM_SETTINGS;
-                _settings_display(state, event.subsecond);
+                _settings_display(event.subsecond);
                 break;
             case EVENT_ALARM_BUTTON_UP:
-                _settings_advance(state);
-                _settings_display(state, event.subsecond);
+                movement_set_wake_on_motion(!movement_get_wake_on_motion());
+                _settings_display(event.subsecond);
                 break;
             case EVENT_MODE_BUTTON_UP:
                 state->is_setting = false;
@@ -166,9 +113,7 @@ bool accelerometer_status_face_loop(movement_event_t event, void *context) {
                 break;
             case EVENT_LIGHT_LONG_PRESS:
                 state->is_setting = true;
-                state->settings_page = 0;
-                state->new_threshold = state->threshold;
-                _settings_display(state, event.subsecond);
+                _settings_display(event.subsecond);
                 break;
             default:
                 movement_default_loop_handler(event);

--- a/watch-faces/sensor/accelerometer_status_face.c
+++ b/watch-faces/sensor/accelerometer_status_face.c
@@ -26,21 +26,77 @@
 #include <string.h>
 #include "accelerometer_status_face.h"
 #include "lis2dw.h"
-#include "tc.h"
 #include "watch.h"
 
-static void _accelerometer_status_face_update_display(accel_interrupt_count_state_t *state) {
-    (void) state;
+/* Default motion threshold: 16 = 0.5 G at +/-2g.
+   This is lower than the default 1G used in movement core because it should
+   track general motion and not just taps on the watch */
+#define ACCEL_DEFAULT_THRESHOLD 16
 
-    // Accelerometer title
+/* Settings pages */
+typedef enum {
+    ACCEL_SETTING_THRESHOLD = 0,
+    ACCEL_SETTING_WAKE,
+} accel_setting_t;
+
+#define ACCEL_NUM_SETTINGS (ACCEL_SETTING_WAKE + 1)
+
+static void _status_display(void) {
     watch_display_text_with_fallback(WATCH_POSITION_TOP, "ACCEL", "AC");
-
-    // sensing is live!
     watch_set_indicator(WATCH_INDICATOR_SIGNAL);
 
-    // Sleep/active state
+    // the motion pin reads HIGH when still at rest, LOW when active
     if (HAL_GPIO_A4_read()) watch_display_text(WATCH_POSITION_BOTTOM, "Still ");
     else watch_display_text_with_fallback(WATCH_POSITION_BOTTOM, "Active", " ACtiv");
+}
+
+static void _settings_title(accel_interrupt_count_state_t *state, const char *primary, const char *fallback) {
+    watch_display_text_with_fallback(WATCH_POSITION_TOP, primary, fallback);
+    if (watch_get_lcd_type() != WATCH_LCD_TYPE_CUSTOM) {
+        char buf[4];
+        snprintf(buf, sizeof(buf), "%2d", state->settings_page + 1);
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+    }
+}
+
+static bool _settings_blink(uint8_t subsecond) {
+    if (subsecond % 2 == 0) {
+        watch_display_text(WATCH_POSITION_BOTTOM, "      ");
+        watch_clear_decimal_if_available();
+        return true;
+    }
+    return false;
+}
+
+static void _settings_display(accel_interrupt_count_state_t *state, uint8_t subsecond) {
+    watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+
+    switch (state->settings_page) {
+        case ACCEL_SETTING_THRESHOLD:
+            _settings_title(state, "THRSH", "TH");
+            if (_settings_blink(subsecond)) return;
+            watch_display_float_with_best_effort(state->new_threshold * 0.03125f, " G");
+            break;
+        case ACCEL_SETTING_WAKE:
+            _settings_title(state, "WAKE ", "WA");
+            if (_settings_blink(subsecond)) return;
+            watch_clear_decimal_if_available();
+            watch_display_text(WATCH_POSITION_BOTTOM, movement_get_wake_on_motion() ? "  on  " : "  off ");
+            break;
+    }
+}
+
+static void _settings_advance(accel_interrupt_count_state_t *state) {
+    switch (state->settings_page) {
+        case ACCEL_SETTING_THRESHOLD:
+            state->new_threshold = (state->new_threshold + 1) % 64;
+            movement_set_accelerometer_motion_threshold(state->new_threshold);
+            state->threshold = state->new_threshold;
+            break;
+        case ACCEL_SETTING_WAKE:
+            movement_set_wake_on_motion(!movement_get_wake_on_motion());
+            break;
+    }
 }
 
 void accelerometer_status_face_setup(uint8_t watch_face_index, void ** context_ptr) {
@@ -48,19 +104,21 @@ void accelerometer_status_face_setup(uint8_t watch_face_index, void ** context_p
     if (*context_ptr == NULL) {
         *context_ptr = malloc(sizeof(accel_interrupt_count_state_t));
         memset(*context_ptr, 0, sizeof(accel_interrupt_count_state_t));
+
+        /* Set up accelerometer and enable background sensing */
+        movement_set_accelerometer_background_rate(LIS2DW_DATA_RATE_LOWEST);
+        movement_set_accelerometer_motion_threshold(ACCEL_DEFAULT_THRESHOLD);
     }
 }
 
 void accelerometer_status_face_activate(void *context) {
     accel_interrupt_count_state_t *state = (accel_interrupt_count_state_t *)context;
 
-    // never in settings mode at the start
     state->is_setting = false;
+    state->settings_page = 0;
 
-    // update more quickly to catch changes, also to blink setting
     movement_request_tick_frequency(4);
 
-    // fetch current threshold from accelerometer
     state->threshold = movement_get_accelerometer_motion_threshold();
 }
 
@@ -68,30 +126,23 @@ bool accelerometer_status_face_loop(movement_event_t event, void *context) {
     accel_interrupt_count_state_t *state = (accel_interrupt_count_state_t *)context;
 
     if (state->is_setting) {
-        watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
         switch (event.event_type) {
-            case EVENT_ALARM_BUTTON_DOWN:
-                state->new_threshold = (state->new_threshold + 1) % 64;
-                // fall through
+            case EVENT_ACTIVATE:
             case EVENT_TICK:
-                {
-                    char buf[11];
-                    if (event.subsecond % 2) {
-                        watch_display_text(WATCH_POSITION_BOTTOM, "      ");
-                        watch_clear_decimal_if_available();
-                    } else {
-                        watch_display_text(WATCH_POSITION_TOP_RIGHT, "  ");
-                        watch_display_text_with_fallback(WATCH_POSITION_TOP, "WAKth", "TH");
-                        watch_display_float_with_best_effort(state->new_threshold * 0.03125, " G");
-                        printf("%s\n", buf);
-                    }
-                }
+                _settings_display(state, event.subsecond);
                 break;
-            case EVENT_LIGHT_BUTTON_DOWN:
-                movement_set_accelerometer_motion_threshold(state->new_threshold);
-                state->threshold = state->new_threshold;
-                watch_clear_decimal_if_available();
+            case EVENT_LIGHT_BUTTON_UP:
+                state->settings_page = (state->settings_page + 1) % ACCEL_NUM_SETTINGS;
+                _settings_display(state, event.subsecond);
+                break;
+            case EVENT_ALARM_BUTTON_UP:
+                _settings_advance(state);
+                _settings_display(state, event.subsecond);
+                break;
+            case EVENT_MODE_BUTTON_UP:
                 state->is_setting = false;
+                watch_clear_decimal_if_available();
+                _status_display();
                 break;
             case EVENT_TIMEOUT:
                 movement_move_to_face(0);
@@ -104,20 +155,21 @@ bool accelerometer_status_face_loop(movement_event_t event, void *context) {
         switch (event.event_type) {
             case EVENT_ACTIVATE:
             case EVENT_TICK:
-                _accelerometer_status_face_update_display(state);
+                _status_display();
                 break;
             case EVENT_LOW_ENERGY_UPDATE:
                 // start tick animation if necessary
                 if (!watch_sleep_animation_is_running()) watch_start_sleep_animation(1000);
-                // update the display
-                _accelerometer_status_face_update_display(state);
+                _status_display();
                 // on classic LCD, clear seconds since they interfere with the sleep animation.
                 if (watch_get_lcd_type() == WATCH_LCD_TYPE_CLASSIC) watch_display_text(WATCH_POSITION_SECONDS, "  ");
                 break;
-            case EVENT_ALARM_LONG_PRESS:
-                state->new_threshold = state->threshold;
+            case EVENT_LIGHT_LONG_PRESS:
                 state->is_setting = true;
-                return false;
+                state->settings_page = 0;
+                state->new_threshold = state->threshold;
+                _settings_display(state, event.subsecond);
+                break;
             default:
                 movement_default_loop_handler(event);
                 break;

--- a/watch-faces/sensor/accelerometer_status_face.h
+++ b/watch-faces/sensor/accelerometer_status_face.h
@@ -25,13 +25,19 @@
 #pragma once
 
 /*
- * Accelerometer Status / Settings
+ * Accelerometer Status and Configuration
  *
- * Meant to be used in conjunction with the activity_logging_face. Shows the current
- * status of the accelerometer active/still status pin, and allows adjusting the
- * motion threshold via a long press of ALARM. Note that this will not work without
- * activity_logging_face in the lineup as activity_logging_face is the one that enables
- * background accelerometer sensing.
+ * This face shows whether the accelerometer currently senses motion (active) or
+ * not (still). It also enables configuring parameters of the accelerometer, such
+ * as the motion threshold and the wake-on-motion support.
+ *
+ * Long-press LIGHT to enter settings, which has two pages. LIGHT cycles between
+ * them, ALARM changes the value, and MODE leaves settings:
+ *   THRSH  the motion threshold, in G
+ *   WAKE   whether motion wakes the watch out of low-energy mode
+ *
+ * The face also enables background accelerometer sensing, making it available to
+ * movement core and other faces; wake-on-motion in particular depends on it.
  */
 
 #include "movement.h"
@@ -41,6 +47,7 @@ typedef struct {
     uint8_t new_threshold;
     uint8_t threshold;
     bool is_setting;
+    uint8_t settings_page;
 } accel_interrupt_count_state_t;
 
 void accelerometer_status_face_setup(uint8_t watch_face_index, void ** context_ptr);

--- a/watch-faces/sensor/accelerometer_status_face.h
+++ b/watch-faces/sensor/accelerometer_status_face.h
@@ -28,26 +28,21 @@
  * Accelerometer Status and Configuration
  *
  * This face shows whether the accelerometer currently senses motion (active) or
- * not (still). It also enables configuring parameters of the accelerometer, such
- * as the motion threshold and the wake-on-motion support.
+ * not (still). It also lets you toggle wake-on-motion support.
  *
- * Long-press LIGHT to enter settings, which has two pages. LIGHT cycles between
- * them, ALARM changes the value, and MODE leaves settings:
- *   THRSH  the motion threshold, in G
+ * Long-press LIGHT to enter settings; ALARM toggles wake-on-motion on or off,
+ * and MODE leaves settings:
  *   WAKE   whether motion wakes the watch out of low-energy mode
  *
  * The face also enables background accelerometer sensing, making it available to
- * movement core and other faces; wake-on-motion in particular depends on it.
+ * movement core and other faces.
  */
 
 #include "movement.h"
 #include "watch.h"
 
 typedef struct {
-    uint8_t new_threshold;
-    uint8_t threshold;
     bool is_setting;
-    uint8_t settings_page;
 } accel_interrupt_count_state_t;
 
 void accelerometer_status_face_setup(uint8_t watch_face_index, void ** context_ptr);


### PR DESCRIPTION
This PR adds wake-on-motion functionality. It allows physical motion to pull the
watch out of low-energy sleep. I developed it for a few reasons:
- It is a preparation for activity faces that require the watch to be awake. In
  low-energy mode the peripherals are off.
- It might save energy, because a smaller low-energy sleep interval can be used,
  such as 10 minutes.
- Finally, it allows you to have an awake watch when you are wearing it, with no
  need to press a button to bring it up.

Costs for this should be minimal, as the accelerometer runs in its lowest power
mode with <1µA.

The implementation rests on small changes to movement core and an extension of
the accelerometer status face.

### Movement core

Two changes to the main implementation:
- New `wake_on_motion` flag with `movement_get_wake_on_motion()` /
  `movement_set_wake_on_motion()`. Off by default.
- Re-enabled the A4 extwake callback. A falling edge wakes the watch from sleep
  and resets the LE inactivity countdown. Returning to sleep is left to the
  normal low-energy timeout.

### Accelerometer status face

The face is reworked into a status view and a settings mode. It also enables
background sensing for wake-on-motion to work.

Status view:
- Shows whether the accelerometer senses motion
- Enter settings with a long light press

Settings pages:
- THRSH — set threshold for motion
- WAKE — enable or disable wake-on-motion
