### PR TITLE
Clamp the lis2dw FIFO count and read it in one burst

### DIFF
--- a/legacy/watch_faces/sensor/accelerometer_data_acquisition_face.c
+++ b/legacy/watch_faces/sensor/accelerometer_data_acquisition_face.c
@@ -448,13 +448,13 @@ static void start_reading(accelerometer_data_acquisition_state_t *state) {
 
     state->records[state->pos++] = record;
     lis2dw_fifo_t fifo;
-    lis2dw_read_fifo(&fifo, LIS2DW_FIFO_TIMEOUT); // dump the fifo, this starts a fresh round of data in continue_reading
+    lis2dw_read_fifo(&fifo); // dump the fifo, this starts a fresh round of data in continue_reading
 }
 
 static void continue_reading(accelerometer_data_acquisition_state_t *state) {
     printf("Continue reading\n");
     lis2dw_fifo_t fifo;
-    lis2dw_read_fifo(&fifo, LIS2DW_FIFO_TIMEOUT);
+    lis2dw_read_fifo(&fifo);
 
     fifo.count = min(fifo.count, 25); // hacky, but we need a consistent data rate; if we got a 26th data point, chuck it.
     uint8_t offset = 4 * (25 - fifo.count); // also hacky: we're sometimes short at the start. align to beginning of next second.

--- a/watch-faces/sensor/lis2dw_monitor_face.c
+++ b/watch-faces/sensor/lis2dw_monitor_face.c
@@ -420,7 +420,7 @@ static void _monitor_update(lis2dw_monitor_state_t *state)
     lis2dw_fifo_t fifo;
     float x = 0, y = 0, z = 0;
 
-    lis2dw_read_fifo(&fifo, LIS2DW_FIFO_TIMEOUT / DISPLAY_FREQUENCY);
+    lis2dw_read_fifo(&fifo);
     if (fifo.count == 0) {
         return;
     }

--- a/watch-library/shared/driver/lis2dw.c
+++ b/watch-library/shared/driver/lis2dw.c
@@ -277,8 +277,7 @@ inline void lis2dw_disable_fifo(void) {
 #endif
 }
 
-bool lis2dw_read_fifo(lis2dw_fifo_t *fifo_data, uint32_t timeout) {
-    // timeout is in terms of 1/RTC_CNT_HZ seconds (likely 128 timeouts is one second)
+bool lis2dw_read_fifo(lis2dw_fifo_t *fifo_data) {
 #ifdef I2C_SERCOM
     uint8_t temp = watch_i2c_read8(LIS2DW_ADDRESS, LIS2DW_REG_FIFO_SAMPLE);
     bool overrun = !!(temp & LIS2DW_FIFO_SAMPLE_OVERRUN);
@@ -291,7 +290,6 @@ bool lis2dw_read_fifo(lis2dw_fifo_t *fifo_data, uint32_t timeout) {
         fifo_data->count = 32;
     }
 
-    (void) timeout; /* unused now; kept in the signature for legacy callers */
     /* Read the whole FIFO in one burst. With address auto-increment (IF_ADD_INC)
        the pointer walks OUT_X_L..OUT_Z_H and rolls over into the next FIFO slot,
        so count*6 bytes returns the samples back-to-back. On this little-endian
@@ -305,7 +303,6 @@ bool lis2dw_read_fifo(lis2dw_fifo_t *fifo_data, uint32_t timeout) {
     return overrun;
 #else
     (void) fifo_data;
-    (void) timeout;
     return false;
 #endif
 }

--- a/watch-library/shared/driver/lis2dw.c
+++ b/watch-library/shared/driver/lis2dw.c
@@ -291,12 +291,15 @@ bool lis2dw_read_fifo(lis2dw_fifo_t *fifo_data, uint32_t timeout) {
         fifo_data->count = 32;
     }
 
-    rtc_counter_t timeout_counter = watch_rtc_get_counter() + timeout;
-    for(int i = 0; i < fifo_data->count; i++) {
-        if (watch_rtc_get_counter() > timeout_counter) {
-            break;
-        }
-        fifo_data->readings[i] = lis2dw_get_raw_reading();
+    (void) timeout; /* unused now; kept in the signature for legacy callers */
+    /* Read the whole FIFO in one burst. With address auto-increment (IF_ADD_INC)
+       the pointer walks OUT_X_L..OUT_Z_H and rolls over into the next FIFO slot,
+       so count*6 bytes returns the samples back-to-back. On this little-endian
+       target the raw bytes map straight onto lis2dw_reading_t (x, y, z int16). */
+    if (fifo_data->count > 0) {
+        uint8_t reg = LIS2DW_REG_OUT_X_L | 0x80;
+        watch_i2c_send(LIS2DW_ADDRESS, &reg, 1);
+        watch_i2c_receive(LIS2DW_ADDRESS, (uint8_t *) fifo_data->readings, fifo_data->count * 6);
     }
 
     return overrun;

--- a/watch-library/shared/driver/lis2dw.c
+++ b/watch-library/shared/driver/lis2dw.c
@@ -285,6 +285,12 @@ bool lis2dw_read_fifo(lis2dw_fifo_t *fifo_data, uint32_t timeout) {
 
     fifo_data->count = temp & LIS2DW_FIFO_SAMPLE_COUNT;
 
+    /* The count field can report up to 63, but readings[] only holds 32.
+       Clamp so a glitched or overrun count can't overflow the buffer. */
+    if (fifo_data->count > 32) {
+        fifo_data->count = 32;
+    }
+
     rtc_counter_t timeout_counter = watch_rtc_get_counter() + timeout;
     for(int i = 0; i < fifo_data->count; i++) {
         if (watch_rtc_get_counter() > timeout_counter) {

--- a/watch-library/shared/driver/lis2dw.h
+++ b/watch-library/shared/driver/lis2dw.h
@@ -301,8 +301,6 @@ typedef enum {
 #define LIS2DW_CTRL7_VAL_HP_REF_MODE        0b00000010
 #define LIS2DW_CTRL7_VAL_LPASS_ON6D         0b00000001
 
-#define LIS2DW_FIFO_TIMEOUT                 100  // timeout is in terms of 1/RTC_CNT_HZ seconds (likely 128 timeouts is one second)
-
 bool lis2dw_begin(void);
 
 uint8_t lis2dw_get_device_id(void);
@@ -347,7 +345,7 @@ void lis2dw_enable_fifo(void);
 
 void lis2dw_disable_fifo(void);
 
-bool lis2dw_read_fifo(lis2dw_fifo_t *fifo_data, uint32_t timeout);
+bool lis2dw_read_fifo(lis2dw_fifo_t *fifo_data);
 
 void lis2dw_clear_fifo(void);
 


### PR DESCRIPTION
Two small changes to lis2dw_read_fifo() in the shared driver. Both help
every caller of the FIFO, not only one face.

1. Clamp the sample count. The count field can report up to 63, but the
readings buffer only holds 32. A glitched or overrun value would write past
the buffer, so this clamps it to 32.

2. Read the whole FIFO in one burst. The old code read one sample at a
time, which costs two I2C transactions per sample. Reading all the samples
in a single transaction makes the cost two transactions per read, no matter
how many samples are queued, and the saving grows with the number of
samples.
