### PR TITLE
Add stopwatch-based game watch faces.

### DIFF
--- a/movement_faces.h
+++ b/movement_faces.h
@@ -85,4 +85,10 @@
 #include "tide_face.h"
 #include "world_clock2_face.h"
 #include "hydration_face.h"
+#include "stopwatch_football_face.h"
+#include "stopwatch_basketball_face.h"
+#include "stopwatch_bullseye_face.h"
+#include "stopwatch_blind_ten_face.h"
+#include "stopwatch_blackjack_face.h"
+#include "stopwatch_f1_pit_stop_face.h"
 // New includes go above this line.

--- a/watch-faces.mk
+++ b/watch-faces.mk
@@ -60,4 +60,11 @@ SRCS += \
   ./watch-faces/clock/solar_time_face.c \
   ./watch-faces/complication/tide_face.c \
   ./watch-faces/clock/world_clock2_face.c \
+  ./watch-faces/complication/stopwatch_game_timing.c \
+  ./watch-faces/complication/stopwatch_football_face.c \
+  ./watch-faces/complication/stopwatch_basketball_face.c \
+  ./watch-faces/complication/stopwatch_bullseye_face.c \
+  ./watch-faces/complication/stopwatch_blind_ten_face.c \
+  ./watch-faces/complication/stopwatch_blackjack_face.c \
+  ./watch-faces/complication/stopwatch_f1_pit_stop_face.c \
 # New watch faces go above this line.

--- a/watch-faces/complication/stopwatch_basketball_face.c
+++ b/watch-faces/complication/stopwatch_basketball_face.c
@@ -1,0 +1,240 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "stopwatch_basketball_face.h"
+
+static const char *result_code(swbb_result_t result) {
+    switch (result) {
+        case SWBB_RESULT_2PT: return "2P";
+        case SWBB_RESULT_3PT: return "3P";
+        case SWBB_RESULT_MISS: return "MS";
+        case SWBB_RESULT_FOUL: return "FL";
+        case SWBB_RESULT_TURNOVER: return "TO";
+        case SWBB_RESULT_FT_MAKE: return "F1";
+        case SWBB_RESULT_FT_MISS: return "F0";
+        default: return "  ";
+    }
+}
+
+static void reset_game(stopwatch_basketball_state_t *state) {
+    memset(state, 0, sizeof(*state));
+    swg_timer_reset(&state->timer);
+    state->quarter = 1;
+    state->phase = SWBB_PHASE_OPEN;
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
+    }
+}
+
+static void end_possession(stopwatch_basketball_state_t *state) {
+    if (state->possessions[state->current_player] < SWBB_POSSESSIONS_PER_QUARTER) {
+        state->possessions[state->current_player]++;
+    }
+
+    if (state->possessions[0] >= SWBB_POSSESSIONS_PER_QUARTER
+            && state->possessions[1] >= SWBB_POSSESSIONS_PER_QUARTER) {
+        if (state->quarter < SWBB_QUARTERS) {
+            state->quarter++;
+            state->possessions[0] = 0;
+            state->possessions[1] = 0;
+            state->current_player = 0;
+            state->phase = SWBB_PHASE_OPEN;
+            return;
+        }
+        state->phase = SWBB_PHASE_OVER;
+        return;
+    }
+
+    state->current_player ^= 1;
+    state->phase = SWBB_PHASE_OPEN;
+}
+
+static void resolve_open(stopwatch_basketball_state_t *state, uint8_t digit) {
+    if (digit <= 2) {
+        state->score[state->current_player] += 2;
+        state->last_result = SWBB_RESULT_2PT;
+        end_possession(state);
+    } else if (digit == 3) {
+        state->score[state->current_player] += 3;
+        state->last_result = SWBB_RESULT_3PT;
+        end_possession(state);
+    } else if (digit <= 5) {
+        state->last_result = SWBB_RESULT_MISS;
+        end_possession(state);
+    } else if (digit <= 7) {
+        state->last_result = SWBB_RESULT_FOUL;
+        state->phase = SWBB_PHASE_FOUL_1;
+    } else {
+        state->last_result = SWBB_RESULT_TURNOVER;
+        end_possession(state);
+    }
+}
+
+static void resolve_foul_shot(stopwatch_basketball_state_t *state, uint8_t digit) {
+    if ((digit % 2) == 0) {
+        state->score[state->current_player] += 1;
+        state->last_result = SWBB_RESULT_FT_MAKE;
+    } else {
+        state->last_result = SWBB_RESULT_FT_MISS;
+    }
+
+    if (state->phase == SWBB_PHASE_FOUL_1) {
+        state->phase = SWBB_PHASE_FOUL_2;
+    } else {
+        end_possession(state);
+    }
+}
+
+static void on_timer_stopped(stopwatch_basketball_state_t *state) {
+    uint8_t digit = swg_last_digit(swg_timer_elapsed_hundredths(&state->timer));
+    if (state->phase == SWBB_PHASE_OPEN) {
+        resolve_open(state, digit);
+    } else if (state->phase == SWBB_PHASE_FOUL_1 || state->phase == SWBB_PHASE_FOUL_2) {
+        resolve_foul_shot(state, digit);
+    }
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C8, 40, movement_button_volume());
+    }
+}
+
+static void update_display(stopwatch_basketball_state_t *state) {
+    char buf[8];
+
+    watch_clear_display();
+    watch_set_colon();
+
+    if (state->phase == SWBB_PHASE_OVER) {
+        watch_display_text(WATCH_POSITION_TOP_LEFT, "WN");
+        if (state->score[0] == state->score[1]) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "TI");
+        } else if (state->score[0] > state->score[1]) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "P1");
+        } else {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "P2");
+        }
+        watch_set_indicator(WATCH_INDICATOR_LAP);
+    } else {
+        sprintf(buf, "P%u", (unsigned)(state->current_player + 1));
+        watch_display_text(WATCH_POSITION_TOP_LEFT, buf);
+        sprintf(buf, "Q%u", (unsigned)state->quarter);
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+        watch_clear_indicator(WATCH_INDICATOR_LAP);
+    }
+
+    if (state->timer.running) {
+        swg_format_hundredths(swg_timer_elapsed_hundredths(&state->timer), buf);
+        watch_display_text(WATCH_POSITION_BOTTOM, buf);
+        return;
+    }
+
+    sprintf(buf, "%02u", (unsigned)state->score[0]);
+    watch_display_text(WATCH_POSITION_HOURS, buf);
+    sprintf(buf, "%02u", (unsigned)state->score[1]);
+    watch_display_text(WATCH_POSITION_MINUTES, buf);
+    if (state->phase == SWBB_PHASE_FOUL_1) {
+        watch_display_text(WATCH_POSITION_SECONDS, "F1");
+    } else if (state->phase == SWBB_PHASE_FOUL_2) {
+        watch_display_text(WATCH_POSITION_SECONDS, "F2");
+    } else {
+        watch_display_text(WATCH_POSITION_SECONDS, result_code(state->last_result));
+    }
+}
+
+void stopwatch_basketball_face_setup(uint8_t watch_face_index, void **context_ptr) {
+    (void)watch_face_index;
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(stopwatch_basketball_state_t));
+        memset(*context_ptr, 0, sizeof(stopwatch_basketball_state_t));
+        stopwatch_basketball_state_t *state = *context_ptr;
+        state->quarter = 1;
+        state->phase = SWBB_PHASE_OPEN;
+    }
+}
+
+void stopwatch_basketball_face_activate(void *context) {
+    stopwatch_basketball_state_t *state = (stopwatch_basketball_state_t *)context;
+    movement_request_tick_frequency(1);
+    update_display(state);
+}
+
+bool stopwatch_basketball_face_loop(movement_event_t event, void *context) {
+    stopwatch_basketball_state_t *state = (stopwatch_basketball_state_t *)context;
+
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            update_display(state);
+            break;
+        case EVENT_TICK:
+            if (state->timer.running) {
+                update_display(state);
+            }
+            break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            if (!state->timer.running) {
+                reset_game(state);
+                movement_request_tick_frequency(1);
+                update_display(state);
+            }
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            if (state->phase == SWBB_PHASE_OVER) {
+                break;
+            }
+            if (state->timer.running) {
+                swg_timer_stop(&state->timer);
+                movement_request_tick_frequency(1);
+                on_timer_stopped(state);
+                update_display(state);
+            } else {
+                swg_timer_start(&state->timer);
+                movement_request_tick_frequency(SWG_UI_TICK_HZ);
+                update_display(state);
+            }
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            reset_game(state);
+            movement_request_tick_frequency(1);
+            update_display(state);
+            break;
+        case EVENT_TIMEOUT:
+            movement_move_to_face(0);
+            break;
+        default:
+            return movement_default_loop_handler(event);
+    }
+    return true;
+}
+
+void stopwatch_basketball_face_resign(void *context) {
+    stopwatch_basketball_state_t *state = (stopwatch_basketball_state_t *)context;
+    if (state->timer.running) {
+        swg_timer_stop(&state->timer);
+    }
+    movement_request_tick_frequency(1);
+}

--- a/watch-faces/complication/stopwatch_basketball_face.h
+++ b/watch-faces/complication/stopwatch_basketball_face.h
@@ -1,0 +1,86 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "movement.h"
+#include "stopwatch_game_timing.h"
+
+/*
+ * Stopwatch Basketball
+ *
+ * Alarm: start/stop. Last digit decides the possession.
+ * Light: reset game (ignored while timer is running).
+ * Alarm long press: also reset game.
+ *
+ * 0-2: 2-pointer | 3: 3-pointer | 4-5: Miss | 6-7: Foul (2 FT)
+ * 8-9: Turnover
+ *
+ * Foul shooting: two separate stops; even = +1, odd = +0 each.
+ * 4 quarters, 10 possessions per player each quarter.
+ */
+
+#define SWBB_POSSESSIONS_PER_QUARTER 10
+#define SWBB_QUARTERS 4
+
+typedef enum {
+    SWBB_PHASE_OPEN = 0,
+    SWBB_PHASE_FOUL_1,
+    SWBB_PHASE_FOUL_2,
+    SWBB_PHASE_OVER,
+} swbb_phase_t;
+
+typedef enum {
+    SWBB_RESULT_NONE = 0,
+    SWBB_RESULT_2PT,
+    SWBB_RESULT_3PT,
+    SWBB_RESULT_MISS,
+    SWBB_RESULT_FOUL,
+    SWBB_RESULT_TURNOVER,
+    SWBB_RESULT_FT_MAKE,
+    SWBB_RESULT_FT_MISS,
+} swbb_result_t;
+
+typedef struct {
+    swg_timer_t timer;
+    uint8_t score[2];
+    uint8_t possessions[2];
+    uint8_t quarter;
+    uint8_t current_player;
+    swbb_phase_t phase;
+    swbb_result_t last_result;
+} stopwatch_basketball_state_t;
+
+void stopwatch_basketball_face_setup(uint8_t watch_face_index, void **context_ptr);
+void stopwatch_basketball_face_activate(void *context);
+bool stopwatch_basketball_face_loop(movement_event_t event, void *context);
+void stopwatch_basketball_face_resign(void *context);
+
+#define stopwatch_basketball_face ((const watch_face_t){ \
+    stopwatch_basketball_face_setup, \
+    stopwatch_basketball_face_activate, \
+    stopwatch_basketball_face_loop, \
+    stopwatch_basketball_face_resign, \
+    NULL, \
+})

--- a/watch-faces/complication/stopwatch_blackjack_face.c
+++ b/watch-faces/complication/stopwatch_blackjack_face.c
@@ -1,0 +1,210 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "stopwatch_blackjack_face.h"
+
+#define SWBJ_POINTS_TO_WIN 3
+
+static void start_player_turn(stopwatch_blackjack_state_t *state) {
+    state->bank[state->current_player] = 0;
+    state->last_draw = 0;
+    state->busted = false;
+    state->phase = SWBJ_NEED_DRAW;
+}
+
+static void reset_match(stopwatch_blackjack_state_t *state) {
+    memset(state, 0, sizeof(*state));
+    swg_timer_reset(&state->timer);
+    start_player_turn(state);
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
+    }
+}
+
+static void finish_player(stopwatch_blackjack_state_t *state) {
+    uint8_t p = state->current_player;
+    state->final_score[p] = state->busted ? 0 : state->bank[p];
+    state->players_finished++;
+
+    if (state->players_finished >= 2) {
+        if (state->final_score[0] > state->final_score[1]) {
+            state->points[0]++;
+        } else if (state->final_score[1] > state->final_score[0]) {
+            state->points[1]++;
+        }
+        if (state->points[0] >= SWBJ_POINTS_TO_WIN || state->points[1] >= SWBJ_POINTS_TO_WIN) {
+            state->phase = SWBJ_MATCH_OVER;
+        } else {
+            state->phase = SWBJ_ROUND_OVER;
+            state->players_finished = 0;
+            state->current_player = 0;
+            start_player_turn(state);
+        }
+        return;
+    }
+
+    state->current_player = 1;
+    start_player_turn(state);
+}
+
+static void apply_draw(stopwatch_blackjack_state_t *state) {
+    uint8_t draw = swg_last_two_digits(swg_timer_elapsed_hundredths(&state->timer));
+    uint8_t p = state->current_player;
+    state->last_draw = draw;
+    uint16_t total = (uint16_t)state->bank[p] + draw;
+    if (total > 100) {
+        state->bank[p] = (uint8_t)total;
+        state->busted = true;
+        finish_player(state);
+    } else {
+        state->bank[p] = (uint8_t)total;
+        state->phase = SWBJ_DECIDE;
+    }
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C8, 40, movement_button_volume());
+    }
+}
+
+static void update_display(stopwatch_blackjack_state_t *state) {
+    char buf[8];
+
+    watch_clear_display();
+    watch_set_colon();
+
+    if (state->phase == SWBJ_MATCH_OVER) {
+        watch_display_text(WATCH_POSITION_TOP_LEFT, "WN");
+        if (state->points[0] > state->points[1]) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "P1");
+        } else if (state->points[1] > state->points[0]) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "P2");
+        } else {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "TI");
+        }
+        watch_set_indicator(WATCH_INDICATOR_LAP);
+    } else {
+        sprintf(buf, "P%u", (unsigned)(state->current_player + 1));
+        watch_display_text(WATCH_POSITION_TOP_LEFT, buf);
+        if (state->phase == SWBJ_DECIDE) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "HS");
+        } else if (state->busted) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "BU");
+        } else {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "HT");
+        }
+        watch_clear_indicator(WATCH_INDICATOR_LAP);
+    }
+
+    if (state->timer.running) {
+        swg_format_hundredths(swg_timer_elapsed_hundredths(&state->timer), buf);
+        watch_display_text(WATCH_POSITION_BOTTOM, buf);
+        return;
+    }
+
+    sprintf(buf, "%02u", (unsigned)state->points[0]);
+    watch_display_text(WATCH_POSITION_HOURS, buf);
+    sprintf(buf, "%02u", (unsigned)(state->bank[state->current_player] % 100));
+    if (state->phase == SWBJ_MATCH_OVER) {
+        sprintf(buf, "%02u", (unsigned)state->points[1]);
+        watch_display_text(WATCH_POSITION_MINUTES, buf);
+    } else {
+        watch_display_text(WATCH_POSITION_MINUTES, buf);
+    }
+    sprintf(buf, "%02u", (unsigned)state->last_draw);
+    watch_display_text(WATCH_POSITION_SECONDS, buf);
+}
+
+void stopwatch_blackjack_face_setup(uint8_t watch_face_index, void **context_ptr) {
+    (void)watch_face_index;
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(stopwatch_blackjack_state_t));
+        memset(*context_ptr, 0, sizeof(stopwatch_blackjack_state_t));
+        start_player_turn((stopwatch_blackjack_state_t *)*context_ptr);
+    }
+}
+
+void stopwatch_blackjack_face_activate(void *context) {
+    stopwatch_blackjack_state_t *state = (stopwatch_blackjack_state_t *)context;
+    movement_request_tick_frequency(1);
+    update_display(state);
+}
+
+bool stopwatch_blackjack_face_loop(movement_event_t event, void *context) {
+    stopwatch_blackjack_state_t *state = (stopwatch_blackjack_state_t *)context;
+
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            update_display(state);
+            break;
+        case EVENT_TICK:
+            if (state->timer.running) {
+                update_display(state);
+            }
+            break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            if (state->phase == SWBJ_DECIDE && !state->timer.running) {
+                finish_player(state);
+                update_display(state);
+            }
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            if (state->phase == SWBJ_MATCH_OVER) {
+                break;
+            }
+            if (state->timer.running) {
+                swg_timer_stop(&state->timer);
+                movement_request_tick_frequency(1);
+                apply_draw(state);
+                update_display(state);
+            } else if (state->phase == SWBJ_NEED_DRAW || state->phase == SWBJ_DECIDE) {
+                swg_timer_start(&state->timer);
+                movement_request_tick_frequency(SWG_UI_TICK_HZ);
+                update_display(state);
+            }
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            reset_match(state);
+            movement_request_tick_frequency(1);
+            update_display(state);
+            break;
+        case EVENT_TIMEOUT:
+            movement_move_to_face(0);
+            break;
+        default:
+            return movement_default_loop_handler(event);
+    }
+    return true;
+}
+
+void stopwatch_blackjack_face_resign(void *context) {
+    stopwatch_blackjack_state_t *state = (stopwatch_blackjack_state_t *)context;
+    if (state->timer.running) {
+        swg_timer_stop(&state->timer);
+    }
+    movement_request_tick_frequency(1);
+}

--- a/watch-faces/complication/stopwatch_blackjack_face.h
+++ b/watch-faces/complication/stopwatch_blackjack_face.h
@@ -1,0 +1,70 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "movement.h"
+#include "stopwatch_game_timing.h"
+
+/*
+ * Stopwatch Blackjack (Target 100)
+ *
+ * Not the card blackjack face. Double-click (start/stop) adds last two digits
+ * (00-99) to your bank. Alarm while stopped = Hit (another draw). Light = Stay.
+ * Bust over 100 scores 0 for the round. Alternate P1/P2; higher under-100 wins.
+ *
+ * Alarm long press: reset match.
+ */
+
+typedef enum {
+    SWBJ_NEED_DRAW = 0,
+    SWBJ_DECIDE,
+    SWBJ_ROUND_OVER,
+    SWBJ_MATCH_OVER,
+} swbj_phase_t;
+
+typedef struct {
+    swg_timer_t timer;
+    uint8_t bank[2];
+    uint8_t final_score[2];
+    uint8_t last_draw;
+    uint8_t points[2];
+    uint8_t current_player;
+    uint8_t players_finished;
+    swbj_phase_t phase;
+    bool busted;
+} stopwatch_blackjack_state_t;
+
+void stopwatch_blackjack_face_setup(uint8_t watch_face_index, void **context_ptr);
+void stopwatch_blackjack_face_activate(void *context);
+bool stopwatch_blackjack_face_loop(movement_event_t event, void *context);
+void stopwatch_blackjack_face_resign(void *context);
+
+#define stopwatch_blackjack_face ((const watch_face_t){ \
+    stopwatch_blackjack_face_setup, \
+    stopwatch_blackjack_face_activate, \
+    stopwatch_blackjack_face_loop, \
+    stopwatch_blackjack_face_resign, \
+    NULL, \
+})

--- a/watch-faces/complication/stopwatch_blind_ten_face.c
+++ b/watch-faces/complication/stopwatch_blind_ten_face.c
@@ -1,0 +1,197 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "stopwatch_blind_ten_face.h"
+
+static void reset_match(stopwatch_blind_ten_state_t *state) {
+    memset(state, 0, sizeof(*state));
+    swg_timer_reset(&state->timer);
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
+    }
+}
+
+static uint32_t delta_from_target(uint32_t hundredths) {
+    if (hundredths >= SWG_TARGET_10_HUNDREDTHS) {
+        return hundredths - SWG_TARGET_10_HUNDREDTHS;
+    }
+    return SWG_TARGET_10_HUNDREDTHS - hundredths;
+}
+
+static void display_hundredths_as_ss_hh(uint32_t hundredths) {
+    char buf[4];
+    uint32_t capped = hundredths;
+    if (capped > 9999) {
+        capped = 9999;
+    }
+    sprintf(buf, "%02lu", (unsigned long)(capped / 100));
+    watch_display_text(WATCH_POSITION_HOURS, buf);
+    sprintf(buf, "%02lu", (unsigned long)(capped % 100));
+    watch_display_text(WATCH_POSITION_MINUTES, buf);
+}
+
+static void on_stop(stopwatch_blind_ten_state_t *state) {
+    state->last_time = swg_timer_elapsed_hundredths(&state->timer);
+    state->last_delta = delta_from_target(state->last_time);
+    state->show_reveal = true;
+    state->pending_delta[state->current_player] = state->last_delta;
+
+    if (state->current_player == 0) {
+        state->has_pending = true;
+        state->current_player = 1;
+    } else {
+        if (state->has_pending) {
+            if (state->pending_delta[0] < state->pending_delta[1]) {
+                state->points[0]++;
+            } else if (state->pending_delta[1] < state->pending_delta[0]) {
+                state->points[1]++;
+            }
+            state->has_pending = false;
+        }
+        state->current_player = 0;
+        if (state->points[0] >= STOPWATCH_BLIND_TEN_POINTS_TO_WIN
+                || state->points[1] >= STOPWATCH_BLIND_TEN_POINTS_TO_WIN) {
+            state->match_over = true;
+        }
+    }
+
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C8, 40, movement_button_volume());
+    }
+}
+
+static void update_display(stopwatch_blind_ten_state_t *state) {
+    char buf[8];
+
+    watch_clear_display();
+    watch_set_colon();
+
+    if (state->match_over) {
+        watch_display_text(WATCH_POSITION_TOP_LEFT, "WN");
+        if (state->points[0] == state->points[1]) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "TI");
+        } else if (state->points[0] > state->points[1]) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "P1");
+        } else {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "P2");
+        }
+        watch_set_indicator(WATCH_INDICATOR_LAP);
+    } else {
+        sprintf(buf, "P%u", (unsigned)(state->current_player + 1));
+        watch_display_text(WATCH_POSITION_TOP_LEFT, buf);
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, "10");
+        watch_clear_indicator(WATCH_INDICATOR_LAP);
+    }
+
+    if (state->timer.running) {
+        watch_display_text(WATCH_POSITION_BOTTOM, "------");
+        return;
+    }
+
+    if (state->match_over || !state->show_reveal) {
+        sprintf(buf, "%02u", (unsigned)state->points[0]);
+        watch_display_text(WATCH_POSITION_HOURS, buf);
+        sprintf(buf, "%02u", (unsigned)state->points[1]);
+        watch_display_text(WATCH_POSITION_MINUTES, buf);
+        watch_display_text(WATCH_POSITION_SECONDS, "Sc");
+        return;
+    }
+
+    /* Full distance from 10.00s, e.g. 761 hundredths -> 07:61 Er */
+    display_hundredths_as_ss_hh(state->last_delta);
+    watch_display_text(WATCH_POSITION_SECONDS, "Er");
+}
+
+void stopwatch_blind_ten_face_setup(uint8_t watch_face_index, void **context_ptr) {
+    (void)watch_face_index;
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(stopwatch_blind_ten_state_t));
+        memset(*context_ptr, 0, sizeof(stopwatch_blind_ten_state_t));
+    }
+}
+
+void stopwatch_blind_ten_face_activate(void *context) {
+    stopwatch_blind_ten_state_t *state = (stopwatch_blind_ten_state_t *)context;
+    movement_request_tick_frequency(1);
+    update_display(state);
+}
+
+bool stopwatch_blind_ten_face_loop(movement_event_t event, void *context) {
+    stopwatch_blind_ten_state_t *state = (stopwatch_blind_ten_state_t *)context;
+
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            update_display(state);
+            break;
+        case EVENT_TICK:
+            break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            if (!state->timer.running) {
+                reset_match(state);
+                movement_request_tick_frequency(1);
+                update_display(state);
+            }
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            if (state->match_over) {
+                break;
+            }
+            if (state->timer.running) {
+                swg_timer_stop(&state->timer);
+                movement_request_tick_frequency(1);
+                on_stop(state);
+                update_display(state);
+            } else {
+                state->show_reveal = false;
+                swg_timer_start(&state->timer);
+                movement_request_tick_frequency(1);
+                update_display(state);
+            }
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            reset_match(state);
+            movement_request_tick_frequency(1);
+            update_display(state);
+            break;
+        case EVENT_TIMEOUT:
+            movement_move_to_face(0);
+            break;
+        default:
+            return movement_default_loop_handler(event);
+    }
+    return true;
+}
+
+void stopwatch_blind_ten_face_resign(void *context) {
+    stopwatch_blind_ten_state_t *state = (stopwatch_blind_ten_state_t *)context;
+    if (state->timer.running) {
+        swg_timer_stop(&state->timer);
+    }
+    movement_request_tick_frequency(1);
+}

--- a/watch-faces/complication/stopwatch_blind_ten_face.h
+++ b/watch-faces/complication/stopwatch_blind_ten_face.h
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "movement.h"
+#include "stopwatch_game_timing.h"
+
+/*
+ * Blind 10-Second Count
+ *
+ * Estimate 10.00 seconds without looking. Display is blank while running.
+ * Closest to 10.00 wins the point. First to 5 points wins.
+ * On reveal, error shows as SS:HH Er (e.g. 07:61 = 7.61s from target).
+ *
+ * Alarm: start/stop.
+ * Light: reset match (ignored while timer is running).
+ * Alarm long press: also reset.
+ */
+
+#define STOPWATCH_BLIND_TEN_POINTS_TO_WIN 5
+
+typedef struct {
+    swg_timer_t timer;
+    uint8_t points[2];
+    uint32_t last_delta;
+    uint32_t pending_delta[2];
+    uint32_t last_time;
+    uint8_t current_player;
+    bool has_pending;
+    bool match_over;
+    bool show_reveal;
+} stopwatch_blind_ten_state_t;
+
+void stopwatch_blind_ten_face_setup(uint8_t watch_face_index, void **context_ptr);
+void stopwatch_blind_ten_face_activate(void *context);
+bool stopwatch_blind_ten_face_loop(movement_event_t event, void *context);
+void stopwatch_blind_ten_face_resign(void *context);
+
+#define stopwatch_blind_ten_face ((const watch_face_t){ \
+    stopwatch_blind_ten_face_setup, \
+    stopwatch_blind_ten_face_activate, \
+    stopwatch_blind_ten_face_loop, \
+    stopwatch_blind_ten_face_resign, \
+    NULL, \
+})

--- a/watch-faces/complication/stopwatch_bullseye_face.c
+++ b/watch-faces/complication/stopwatch_bullseye_face.c
@@ -1,0 +1,194 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "stopwatch_bullseye_face.h"
+
+static void reset_match(stopwatch_bullseye_state_t *state) {
+    memset(state, 0, sizeof(*state));
+    swg_timer_reset(&state->timer);
+    state->round = 1;
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
+    }
+}
+
+static uint16_t delta_from_target(uint32_t hundredths) {
+    if (hundredths >= SWG_TARGET_10_HUNDREDTHS) {
+        return (uint16_t)(hundredths - SWG_TARGET_10_HUNDREDTHS);
+    }
+    return (uint16_t)(SWG_TARGET_10_HUNDREDTHS - hundredths);
+}
+
+static void on_stop(stopwatch_bullseye_state_t *state) {
+    uint32_t hundredths = swg_timer_elapsed_hundredths(&state->timer);
+    state->last_delta = delta_from_target(hundredths);
+    state->total[state->current_player] += state->last_delta;
+
+    if (state->current_player == 1) {
+        if (state->round >= STOPWATCH_BULLSEYE_ROUNDS) {
+            state->match_over = true;
+        } else {
+            state->round++;
+        }
+    }
+    state->current_player ^= 1;
+
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C8, 40, movement_button_volume());
+    }
+}
+
+static void display_hundredths_as_ss_hh(uint16_t hundredths) {
+    char buf[4];
+    uint16_t capped = hundredths;
+    if (capped > 9999) {
+        capped = 9999;
+    }
+    sprintf(buf, "%02u", (unsigned)(capped / 100));
+    watch_display_text(WATCH_POSITION_HOURS, buf);
+    sprintf(buf, "%02u", (unsigned)(capped % 100));
+    watch_display_text(WATCH_POSITION_MINUTES, buf);
+}
+
+static void update_display(stopwatch_bullseye_state_t *state) {
+    char buf[8];
+
+    watch_clear_display();
+    watch_set_colon();
+
+    if (state->match_over) {
+        watch_display_text(WATCH_POSITION_TOP_LEFT, "WN");
+        if (state->total[0] == state->total[1]) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "TI");
+        } else if (state->total[0] < state->total[1]) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "P1");
+        } else {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "P2");
+        }
+        watch_set_indicator(WATCH_INDICATOR_LAP);
+    } else {
+        sprintf(buf, "P%u", (unsigned)(state->current_player + 1));
+        watch_display_text(WATCH_POSITION_TOP_LEFT, buf);
+        sprintf(buf, "R%u", (unsigned)state->round);
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+        watch_clear_indicator(WATCH_INDICATOR_LAP);
+    }
+
+    if (state->timer.running) {
+        swg_format_hundredths(swg_timer_elapsed_hundredths(&state->timer), buf);
+        watch_display_text(WATCH_POSITION_BOTTOM, buf);
+        return;
+    }
+
+    if (state->match_over) {
+        uint16_t t0 = state->total[0] > 9999 ? 9999 : state->total[0];
+        uint16_t t1 = state->total[1] > 9999 ? 9999 : state->total[1];
+        sprintf(buf, "%02u", (unsigned)(t0 / 100));
+        watch_display_text(WATCH_POSITION_HOURS, buf);
+        sprintf(buf, "%02u", (unsigned)(t1 / 100));
+        watch_display_text(WATCH_POSITION_MINUTES, buf);
+        watch_display_text(WATCH_POSITION_SECONDS, "Sc");
+        return;
+    }
+
+    /* Last error from 10.00s, e.g. 761 hundredths -> 07:61 Er (7.61s away). */
+    display_hundredths_as_ss_hh(state->last_delta);
+    watch_display_text(WATCH_POSITION_SECONDS, "Er");
+}
+
+void stopwatch_bullseye_face_setup(uint8_t watch_face_index, void **context_ptr) {
+    (void)watch_face_index;
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(stopwatch_bullseye_state_t));
+        memset(*context_ptr, 0, sizeof(stopwatch_bullseye_state_t));
+        ((stopwatch_bullseye_state_t *)*context_ptr)->round = 1;
+    }
+}
+
+void stopwatch_bullseye_face_activate(void *context) {
+    stopwatch_bullseye_state_t *state = (stopwatch_bullseye_state_t *)context;
+    movement_request_tick_frequency(1);
+    update_display(state);
+}
+
+bool stopwatch_bullseye_face_loop(movement_event_t event, void *context) {
+    stopwatch_bullseye_state_t *state = (stopwatch_bullseye_state_t *)context;
+
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            update_display(state);
+            break;
+        case EVENT_TICK:
+            if (state->timer.running) {
+                update_display(state);
+            }
+            break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            if (!state->timer.running) {
+                reset_match(state);
+                movement_request_tick_frequency(1);
+                update_display(state);
+            }
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            if (state->match_over) {
+                break;
+            }
+            if (state->timer.running) {
+                swg_timer_stop(&state->timer);
+                movement_request_tick_frequency(1);
+                on_stop(state);
+                update_display(state);
+            } else {
+                swg_timer_start(&state->timer);
+                movement_request_tick_frequency(SWG_UI_TICK_HZ);
+                update_display(state);
+            }
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            reset_match(state);
+            movement_request_tick_frequency(1);
+            update_display(state);
+            break;
+        case EVENT_TIMEOUT:
+            movement_move_to_face(0);
+            break;
+        default:
+            return movement_default_loop_handler(event);
+    }
+    return true;
+}
+
+void stopwatch_bullseye_face_resign(void *context) {
+    stopwatch_bullseye_state_t *state = (stopwatch_bullseye_state_t *)context;
+    if (state->timer.running) {
+        swg_timer_stop(&state->timer);
+    }
+    movement_request_tick_frequency(1);
+}

--- a/watch-faces/complication/stopwatch_bullseye_face.h
+++ b/watch-faces/complication/stopwatch_bullseye_face.h
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "movement.h"
+#include "stopwatch_game_timing.h"
+
+/*
+ * Bullseye (Target 10.00 seconds)
+ *
+ * Stop as close to 10.00s as possible (not 1:00).
+ * Score = |elapsed - 10.00| in hundredths of a second.
+ * Example: stop at 2.39 -> error 7.61s -> shows 07:61 Er
+ * 5 rounds alternating P1/P2. Lowest cumulative total wins.
+ *
+ * Alarm: start/stop.
+ * Light: reset match (ignored while timer is running).
+ * Alarm long press: also reset.
+ */
+
+#define STOPWATCH_BULLSEYE_ROUNDS 5
+
+typedef struct {
+    swg_timer_t timer;
+    uint16_t total[2];
+    uint16_t last_delta;
+    uint8_t round;
+    uint8_t current_player;
+    bool match_over;
+} stopwatch_bullseye_state_t;
+
+void stopwatch_bullseye_face_setup(uint8_t watch_face_index, void **context_ptr);
+void stopwatch_bullseye_face_activate(void *context);
+bool stopwatch_bullseye_face_loop(movement_event_t event, void *context);
+void stopwatch_bullseye_face_resign(void *context);
+
+#define stopwatch_bullseye_face ((const watch_face_t){ \
+    stopwatch_bullseye_face_setup, \
+    stopwatch_bullseye_face_activate, \
+    stopwatch_bullseye_face_loop, \
+    stopwatch_bullseye_face_resign, \
+    NULL, \
+})

--- a/watch-faces/complication/stopwatch_f1_pit_stop_face.c
+++ b/watch-faces/complication/stopwatch_f1_pit_stop_face.c
@@ -1,0 +1,204 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "stopwatch_f1_pit_stop_face.h"
+
+static void reset_match(stopwatch_f1_pit_stop_state_t *state) {
+    memset(state, 0, sizeof(*state));
+    swg_timer_reset(&state->timer);
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
+    }
+}
+
+static uint16_t average_for(const stopwatch_f1_pit_stop_state_t *state, uint8_t player) {
+    uint32_t sum = 0;
+    uint8_t n = state->attempt[player];
+    if (n == 0) {
+        return 0;
+    }
+    for (uint8_t i = 0; i < n; i++) {
+        sum += state->times[player][i];
+    }
+    return (uint16_t)(sum / n);
+}
+
+static void on_stop(stopwatch_f1_pit_stop_state_t *state) {
+    uint8_t p = state->current_player;
+    uint8_t idx = state->attempt[p];
+    uint32_t hundredths = swg_timer_elapsed_hundredths(&state->timer);
+    if (hundredths > 9999) {
+        hundredths = 9999;
+    }
+    state->last_time = (uint16_t)hundredths;
+    if (idx < STOPWATCH_F1_ATTEMPTS) {
+        state->times[p][idx] = state->last_time;
+        state->attempt[p]++;
+    }
+
+    if (state->attempt[0] >= STOPWATCH_F1_ATTEMPTS && state->attempt[1] >= STOPWATCH_F1_ATTEMPTS) {
+        state->match_over = true;
+    } else if (state->attempt[p] >= STOPWATCH_F1_ATTEMPTS) {
+        state->current_player ^= 1;
+    } else {
+        state->current_player ^= 1;
+        if (state->attempt[state->current_player] >= STOPWATCH_F1_ATTEMPTS) {
+            state->current_player ^= 1;
+        }
+    }
+
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C8, 40, movement_button_volume());
+    }
+}
+
+static void update_display(stopwatch_f1_pit_stop_state_t *state) {
+    char buf[8];
+
+    watch_clear_display();
+    watch_set_colon();
+
+    if (state->match_over) {
+        uint16_t avg0 = average_for(state, 0);
+        uint16_t avg1 = average_for(state, 1);
+        watch_display_text(WATCH_POSITION_TOP_LEFT, "WN");
+        if (avg0 == avg1) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "TI");
+        } else if (avg0 < avg1) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "P1");
+        } else {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "P2");
+        }
+        watch_set_indicator(WATCH_INDICATOR_LAP);
+        sprintf(buf, "%02u", (unsigned)(avg0 % 100));
+        watch_display_text(WATCH_POSITION_HOURS, buf);
+        sprintf(buf, "%02u", (unsigned)(avg1 % 100));
+        watch_display_text(WATCH_POSITION_MINUTES, buf);
+        sprintf(buf, "%02u", (unsigned)(state->last_time % 100));
+        watch_display_text(WATCH_POSITION_SECONDS, buf);
+        return;
+    }
+
+    sprintf(buf, "P%u", (unsigned)(state->current_player + 1));
+    watch_display_text(WATCH_POSITION_TOP_LEFT, buf);
+    sprintf(buf, "A%u", (unsigned)(state->attempt[state->current_player] + 1));
+    if (state->attempt[state->current_player] >= STOPWATCH_F1_ATTEMPTS) {
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, "OK");
+    } else {
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+    }
+    watch_clear_indicator(WATCH_INDICATOR_LAP);
+
+    if (state->timer.running) {
+        swg_format_hundredths(swg_timer_elapsed_hundredths(&state->timer), buf);
+        watch_display_text(WATCH_POSITION_BOTTOM, buf);
+        return;
+    }
+
+    uint16_t avg = average_for(state, state->current_player);
+    sprintf(buf, "%02u", (unsigned)(avg % 100));
+    watch_display_text(WATCH_POSITION_HOURS, buf);
+    sprintf(buf, "%02u", (unsigned)(state->last_time / 100 % 100));
+    watch_display_text(WATCH_POSITION_MINUTES, buf);
+    sprintf(buf, "%02u", (unsigned)(state->last_time % 100));
+    watch_display_text(WATCH_POSITION_SECONDS, buf);
+}
+
+void stopwatch_f1_pit_stop_face_setup(uint8_t watch_face_index, void **context_ptr) {
+    (void)watch_face_index;
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(stopwatch_f1_pit_stop_state_t));
+        memset(*context_ptr, 0, sizeof(stopwatch_f1_pit_stop_state_t));
+    }
+}
+
+void stopwatch_f1_pit_stop_face_activate(void *context) {
+    stopwatch_f1_pit_stop_state_t *state = (stopwatch_f1_pit_stop_state_t *)context;
+    movement_request_tick_frequency(1);
+    update_display(state);
+}
+
+bool stopwatch_f1_pit_stop_face_loop(movement_event_t event, void *context) {
+    stopwatch_f1_pit_stop_state_t *state = (stopwatch_f1_pit_stop_state_t *)context;
+
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            update_display(state);
+            break;
+        case EVENT_TICK:
+            if (state->timer.running) {
+                update_display(state);
+            }
+            break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            if (!state->timer.running) {
+                reset_match(state);
+                movement_request_tick_frequency(1);
+                update_display(state);
+            }
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            if (state->match_over) {
+                break;
+            }
+            if (state->attempt[state->current_player] >= STOPWATCH_F1_ATTEMPTS) {
+                break;
+            }
+            if (state->timer.running) {
+                swg_timer_stop(&state->timer);
+                movement_request_tick_frequency(1);
+                on_stop(state);
+                update_display(state);
+            } else {
+                swg_timer_start(&state->timer);
+                movement_request_tick_frequency(SWG_UI_TICK_HZ);
+                update_display(state);
+            }
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            reset_match(state);
+            movement_request_tick_frequency(1);
+            update_display(state);
+            break;
+        case EVENT_TIMEOUT:
+            movement_move_to_face(0);
+            break;
+        default:
+            return movement_default_loop_handler(event);
+    }
+    return true;
+}
+
+void stopwatch_f1_pit_stop_face_resign(void *context) {
+    stopwatch_f1_pit_stop_state_t *state = (stopwatch_f1_pit_stop_state_t *)context;
+    if (state->timer.running) {
+        swg_timer_stop(&state->timer);
+    }
+    movement_request_tick_frequency(1);
+}

--- a/watch-faces/complication/stopwatch_f1_pit_stop_face.h
+++ b/watch-faces/complication/stopwatch_f1_pit_stop_face.h
@@ -1,0 +1,63 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "movement.h"
+#include "stopwatch_game_timing.h"
+
+/*
+ * F1 Pit Stop Challenge
+ *
+ * Fastest start/stop double-click. Best of 5 attempts per player.
+ * Lowest average hundredths wins.
+ *
+ * Alarm: start/stop.
+ * Light: reset (ignored while timer is running).
+ * Alarm long press: also reset.
+ */
+
+#define STOPWATCH_F1_ATTEMPTS 5
+
+typedef struct {
+    swg_timer_t timer;
+    uint16_t times[2][STOPWATCH_F1_ATTEMPTS];
+    uint16_t last_time;
+    uint8_t attempt[2];
+    uint8_t current_player;
+    bool match_over;
+} stopwatch_f1_pit_stop_state_t;
+
+void stopwatch_f1_pit_stop_face_setup(uint8_t watch_face_index, void **context_ptr);
+void stopwatch_f1_pit_stop_face_activate(void *context);
+bool stopwatch_f1_pit_stop_face_loop(movement_event_t event, void *context);
+void stopwatch_f1_pit_stop_face_resign(void *context);
+
+#define stopwatch_f1_pit_stop_face ((const watch_face_t){ \
+    stopwatch_f1_pit_stop_face_setup, \
+    stopwatch_f1_pit_stop_face_activate, \
+    stopwatch_f1_pit_stop_face_loop, \
+    stopwatch_f1_pit_stop_face_resign, \
+    NULL, \
+})

--- a/watch-faces/complication/stopwatch_football_face.c
+++ b/watch-faces/complication/stopwatch_football_face.c
@@ -1,0 +1,393 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "stopwatch_football_face.h"
+
+static const char *result_code(stopwatch_football_result_t result) {
+    switch (result) {
+        case SOC_RESULT_GOAL: return "GL";
+        case SOC_RESULT_PENALTY: return "PN";
+        case SOC_RESULT_CORNER: return "CN";
+        case SOC_RESULT_FREE_KICK: return "FK";
+        case SOC_RESULT_MISS: return "MS";
+        case SOC_RESULT_SAVE: return "SV";
+        case SOC_RESULT_YELLOW: return "YC";
+        case SOC_RESULT_RED: return "RC";
+        case SOC_RESULT_OFFSIDE: return "OS";
+        case SOC_RESULT_CLEARED: return "CL";
+        case SOC_RESULT_BLOCKED: return "BL";
+        case SOC_RESULT_PK_GOAL: return "PG";
+        case SOC_RESULT_PK_MISS: return "PM";
+        default: return "  ";
+    }
+}
+
+static void reset_match(stopwatch_football_state_t *state) {
+    memset(state, 0, sizeof(*state));
+    swg_timer_reset(&state->timer);
+    state->half = 1;
+    state->phase = SOC_PHASE_OPEN;
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C7, 50, movement_button_volume());
+    }
+}
+
+static void switch_player(stopwatch_football_state_t *state) {
+    state->current_player ^= 1;
+}
+
+static bool half_complete(const stopwatch_football_state_t *state) {
+    return state->turns[0] >= STOPWATCH_FOOTBALL_TURNS_PER_HALF
+        && state->turns[1] >= STOPWATCH_FOOTBALL_TURNS_PER_HALF;
+}
+
+static bool shootout_decided(const stopwatch_football_state_t *state) {
+    uint8_t rem0 = STOPWATCH_FOOTBALL_PK_ATTEMPTS - state->pk_taken[0];
+    uint8_t rem1 = STOPWATCH_FOOTBALL_PK_ATTEMPTS - state->pk_taken[1];
+    if (state->pk_made[0] > state->pk_made[1] + rem1) {
+        return true;
+    }
+    if (state->pk_made[1] > state->pk_made[0] + rem0) {
+        return true;
+    }
+    return state->pk_taken[0] >= STOPWATCH_FOOTBALL_PK_ATTEMPTS
+        && state->pk_taken[1] >= STOPWATCH_FOOTBALL_PK_ATTEMPTS;
+}
+
+static void after_possession(stopwatch_football_state_t *state, bool count_turn) {
+    if (count_turn && state->phase != SOC_PHASE_SHOOTOUT) {
+        if (state->turns[state->current_player] < STOPWATCH_FOOTBALL_TURNS_PER_HALF) {
+            state->turns[state->current_player]++;
+        }
+    }
+
+    if (state->phase == SOC_PHASE_SHOOTOUT) {
+        switch_player(state);
+        if (shootout_decided(state)) {
+            state->phase = SOC_PHASE_MATCH_OVER;
+        }
+        return;
+    }
+
+    if (half_complete(state)) {
+        if (state->half == 1) {
+            state->half = 2;
+            state->turns[0] = 0;
+            state->turns[1] = 0;
+            state->current_player = 0;
+            state->phase = SOC_PHASE_OPEN;
+            return;
+        }
+        if (state->score[0] == state->score[1]) {
+            state->phase = SOC_PHASE_SHOOTOUT;
+            state->pk_made[0] = 0;
+            state->pk_made[1] = 0;
+            state->pk_taken[0] = 0;
+            state->pk_taken[1] = 0;
+            state->current_player = 0;
+            state->last_result = SOC_RESULT_NONE;
+            return;
+        }
+        state->phase = SOC_PHASE_MATCH_OVER;
+        return;
+    }
+
+    switch_player(state);
+    state->phase = SOC_PHASE_OPEN;
+}
+
+static void score_goal(stopwatch_football_state_t *state) {
+    state->score[state->current_player]++;
+    state->last_result = SOC_RESULT_GOAL;
+}
+
+static void resolve_open_digit(stopwatch_football_state_t *state, uint8_t digit) {
+    switch (digit) {
+        case 0:
+        case 9:
+            score_goal(state);
+            after_possession(state, true);
+            break;
+        case 1:
+            state->phase = SOC_PHASE_PENALTY;
+            state->last_result = SOC_RESULT_PENALTY;
+            break;
+        case 2:
+            state->phase = SOC_PHASE_CORNER;
+            state->last_result = SOC_RESULT_CORNER;
+            break;
+        case 3:
+            state->phase = SOC_PHASE_FREE_KICK;
+            state->last_result = SOC_RESULT_FREE_KICK;
+            break;
+        case 4:
+            state->last_result = SOC_RESULT_MISS;
+            after_possession(state, true);
+            break;
+        case 5:
+            state->last_result = SOC_RESULT_SAVE;
+            after_possession(state, true);
+            break;
+        case 6:
+            state->last_result = SOC_RESULT_YELLOW;
+            after_possession(state, true);
+            break;
+        case 7:
+            state->last_result = SOC_RESULT_RED;
+            if (state->turns[state->current_player] < STOPWATCH_FOOTBALL_TURNS_PER_HALF) {
+                state->turns[state->current_player]++;
+            }
+            switch_player(state);
+            state->phase = SOC_PHASE_RED_PK;
+            break;
+        case 8:
+            state->last_result = SOC_RESULT_OFFSIDE;
+            after_possession(state, true);
+            break;
+        default:
+            break;
+    }
+}
+
+static void check_half_or_match_end(stopwatch_football_state_t *state) {
+    if (!half_complete(state)) {
+        return;
+    }
+    if (state->half == 1) {
+        state->half = 2;
+        state->turns[0] = 0;
+        state->turns[1] = 0;
+        state->current_player = 0;
+        state->phase = SOC_PHASE_OPEN;
+        return;
+    }
+    if (state->score[0] == state->score[1]) {
+        state->phase = SOC_PHASE_SHOOTOUT;
+        state->pk_made[0] = 0;
+        state->pk_made[1] = 0;
+        state->pk_taken[0] = 0;
+        state->pk_taken[1] = 0;
+        state->current_player = 0;
+        state->last_result = SOC_RESULT_NONE;
+        return;
+    }
+    state->phase = SOC_PHASE_MATCH_OVER;
+}
+
+static void resolve_set_piece(stopwatch_football_state_t *state, uint8_t digit) {
+    bool goal = false;
+    bool red_pk = (state->phase == SOC_PHASE_RED_PK);
+
+    if (state->phase == SOC_PHASE_PENALTY || red_pk) {
+        goal = (digit % 2) == 0;
+        state->last_result = goal ? SOC_RESULT_PK_GOAL : SOC_RESULT_PK_MISS;
+    } else if (state->phase == SOC_PHASE_CORNER) {
+        goal = (digit >= 1 && digit <= 3);
+        state->last_result = goal ? SOC_RESULT_GOAL : SOC_RESULT_CLEARED;
+    } else if (state->phase == SOC_PHASE_FREE_KICK) {
+        goal = (digit == 1 || digit == 2);
+        state->last_result = goal ? SOC_RESULT_GOAL : SOC_RESULT_BLOCKED;
+    }
+
+    if (goal) {
+        state->score[state->current_player]++;
+    }
+
+    if (red_pk) {
+        if (state->turns[state->current_player] < STOPWATCH_FOOTBALL_TURNS_PER_HALF) {
+            state->turns[state->current_player]++;
+        }
+        switch_player(state);
+        state->phase = SOC_PHASE_OPEN;
+        check_half_or_match_end(state);
+        return;
+    }
+
+    after_possession(state, true);
+}
+
+static void resolve_shootout(stopwatch_football_state_t *state, uint8_t digit) {
+    bool goal = (digit % 2) == 0;
+    uint8_t p = state->current_player;
+    state->pk_taken[p]++;
+    if (goal) {
+        state->pk_made[p]++;
+        state->score[p]++;
+        state->last_result = SOC_RESULT_PK_GOAL;
+    } else {
+        state->last_result = SOC_RESULT_PK_MISS;
+    }
+    after_possession(state, false);
+}
+
+static void on_timer_stopped(stopwatch_football_state_t *state) {
+    uint32_t hundredths = swg_timer_elapsed_hundredths(&state->timer);
+    uint8_t digit = swg_last_digit(hundredths);
+
+    if (state->phase == SOC_PHASE_SHOOTOUT) {
+        resolve_shootout(state, digit);
+    } else if (state->phase == SOC_PHASE_OPEN) {
+        resolve_open_digit(state, digit);
+    } else if (state->phase == SOC_PHASE_PENALTY
+            || state->phase == SOC_PHASE_CORNER
+            || state->phase == SOC_PHASE_FREE_KICK
+            || state->phase == SOC_PHASE_RED_PK) {
+        resolve_set_piece(state, digit);
+    }
+
+    if (movement_button_should_sound()) {
+        watch_buzzer_play_note_with_volume(BUZZER_NOTE_C8, 40, movement_button_volume());
+    }
+}
+
+static void update_display(stopwatch_football_state_t *state) {
+    char buf[8];
+
+    watch_clear_display();
+    watch_set_colon();
+
+    if (state->phase == SOC_PHASE_MATCH_OVER) {
+        watch_display_text(WATCH_POSITION_TOP_LEFT, "WN");
+        if (state->score[0] == state->score[1]) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "FT");
+        } else if (state->score[0] > state->score[1]) {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "P1");
+        } else {
+            watch_display_text(WATCH_POSITION_TOP_RIGHT, "P2");
+        }
+    } else if (state->phase == SOC_PHASE_SHOOTOUT) {
+        sprintf(buf, "P%u", (unsigned)(state->current_player + 1));
+        watch_display_text(WATCH_POSITION_TOP_LEFT, buf);
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, "PK");
+    } else {
+        sprintf(buf, "P%u", (unsigned)(state->current_player + 1));
+        watch_display_text(WATCH_POSITION_TOP_LEFT, buf);
+        sprintf(buf, "H%u", (unsigned)state->half);
+        watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+    }
+
+    if (state->timer.running) {
+        swg_format_hundredths(swg_timer_elapsed_hundredths(&state->timer), buf);
+        watch_display_text(WATCH_POSITION_BOTTOM, buf);
+        return;
+    }
+
+    sprintf(buf, "%02u", (unsigned)state->score[0]);
+    watch_display_text(WATCH_POSITION_HOURS, buf);
+    sprintf(buf, "%02u", (unsigned)state->score[1]);
+    watch_display_text(WATCH_POSITION_MINUTES, buf);
+    watch_display_text(WATCH_POSITION_SECONDS, result_code(state->last_result));
+
+    if (state->phase == SOC_PHASE_MATCH_OVER) {
+        watch_set_indicator(WATCH_INDICATOR_LAP);
+    } else {
+        watch_clear_indicator(WATCH_INDICATOR_LAP);
+    }
+}
+
+void stopwatch_football_face_setup(uint8_t watch_face_index, void **context_ptr) {
+    (void)watch_face_index;
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(stopwatch_football_state_t));
+        memset(*context_ptr, 0, sizeof(stopwatch_football_state_t));
+        stopwatch_football_state_t *state = *context_ptr;
+        state->half = 1;
+        state->phase = SOC_PHASE_OPEN;
+    }
+}
+
+void stopwatch_football_face_activate(void *context) {
+    stopwatch_football_state_t *state = (stopwatch_football_state_t *)context;
+    movement_request_tick_frequency(1);
+    update_display(state);
+}
+
+bool stopwatch_football_face_loop(movement_event_t event, void *context) {
+    stopwatch_football_state_t *state = (stopwatch_football_state_t *)context;
+
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            update_display(state);
+            break;
+
+        case EVENT_TICK:
+            if (state->timer.running) {
+                update_display(state);
+            }
+            break;
+
+        case EVENT_LIGHT_BUTTON_DOWN:
+            break;
+
+        case EVENT_LIGHT_BUTTON_UP:
+            if (!state->timer.running) {
+                reset_match(state);
+                movement_request_tick_frequency(1);
+                update_display(state);
+            }
+            break;
+
+        case EVENT_ALARM_BUTTON_UP:
+            if (state->phase == SOC_PHASE_MATCH_OVER) {
+                break;
+            }
+            if (state->timer.running) {
+                swg_timer_stop(&state->timer);
+                movement_request_tick_frequency(1);
+                on_timer_stopped(state);
+                update_display(state);
+            } else {
+                swg_timer_start(&state->timer);
+                movement_request_tick_frequency(SWG_UI_TICK_HZ);
+                update_display(state);
+            }
+            break;
+
+        case EVENT_ALARM_LONG_PRESS:
+            reset_match(state);
+            movement_request_tick_frequency(1);
+            update_display(state);
+            break;
+
+        case EVENT_TIMEOUT:
+            movement_move_to_face(0);
+            break;
+
+        default:
+            return movement_default_loop_handler(event);
+    }
+
+    return true;
+}
+
+void stopwatch_football_face_resign(void *context) {
+    stopwatch_football_state_t *state = (stopwatch_football_state_t *)context;
+    if (state->timer.running) {
+        swg_timer_stop(&state->timer);
+    }
+    movement_request_tick_frequency(1);
+}

--- a/watch-faces/complication/stopwatch_football_face.h
+++ b/watch-faces/complication/stopwatch_football_face.h
@@ -1,0 +1,104 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "movement.h"
+#include "stopwatch_game_timing.h"
+
+/*
+ * Casio Soccer / Stopwatch Football
+ *
+ * Alarm: start/stop the stopwatch. Last digit decides the play.
+ * Light: reset match (ignored while timer is running).
+ * Alarm long press: also reset match.
+ *
+ * Open play (last digit):
+ *  0,9 Goal | 1 Penalty | 2 Corner | 3 Free kick | 4 Miss
+ *  5 Save | 6 Yellow | 7 Red (opponent PK) | 8 Offside
+ *
+ * Set pieces resolved on the next stop:
+ *  Penalty: even Goal, odd Miss
+ *  Corner: 1-3 Goal, else Cleared
+ *  Free kick: 1-2 Goal, else Blocked
+ *
+ * Match: 2 halves, 10 turns per player each. Tied FT -> 5 PK each.
+ *
+ * Display: P1/P2, H1/H2/PK, score, phase code (GL/PN/CN/FK/MS/SV/YC/RC/OS).
+ */
+
+#define STOPWATCH_FOOTBALL_TURNS_PER_HALF 10
+#define STOPWATCH_FOOTBALL_PK_ATTEMPTS 5
+
+typedef enum {
+    SOC_PHASE_OPEN = 0,
+    SOC_PHASE_PENALTY,
+    SOC_PHASE_CORNER,
+    SOC_PHASE_FREE_KICK,
+    SOC_PHASE_RED_PK,
+    SOC_PHASE_SHOOTOUT,
+    SOC_PHASE_MATCH_OVER,
+} stopwatch_football_phase_t;
+
+typedef enum {
+    SOC_RESULT_NONE = 0,
+    SOC_RESULT_GOAL,
+    SOC_RESULT_PENALTY,
+    SOC_RESULT_CORNER,
+    SOC_RESULT_FREE_KICK,
+    SOC_RESULT_MISS,
+    SOC_RESULT_SAVE,
+    SOC_RESULT_YELLOW,
+    SOC_RESULT_RED,
+    SOC_RESULT_OFFSIDE,
+    SOC_RESULT_CLEARED,
+    SOC_RESULT_BLOCKED,
+    SOC_RESULT_PK_GOAL,
+    SOC_RESULT_PK_MISS,
+} stopwatch_football_result_t;
+
+typedef struct {
+    swg_timer_t timer;
+    uint8_t score[2];
+    uint8_t turns[2];
+    uint8_t half;
+    uint8_t current_player;
+    stopwatch_football_phase_t phase;
+    stopwatch_football_result_t last_result;
+    uint8_t pk_made[2];
+    uint8_t pk_taken[2];
+} stopwatch_football_state_t;
+
+void stopwatch_football_face_setup(uint8_t watch_face_index, void **context_ptr);
+void stopwatch_football_face_activate(void *context);
+bool stopwatch_football_face_loop(movement_event_t event, void *context);
+void stopwatch_football_face_resign(void *context);
+
+#define stopwatch_football_face ((const watch_face_t){ \
+    stopwatch_football_face_setup, \
+    stopwatch_football_face_activate, \
+    stopwatch_football_face_loop, \
+    stopwatch_football_face_resign, \
+    NULL, \
+})

--- a/watch-faces/complication/stopwatch_game_timing.c
+++ b/watch-faces/complication/stopwatch_game_timing.c
@@ -1,0 +1,81 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include "stopwatch_game_timing.h"
+
+void swg_timer_reset(swg_timer_t *timer) {
+    timer->start_counter = 0;
+    timer->stop_counter = 0;
+    timer->running = false;
+}
+
+void swg_timer_start(swg_timer_t *timer) {
+    timer->start_counter = watch_rtc_get_counter();
+    timer->stop_counter = timer->start_counter;
+    timer->running = true;
+}
+
+void swg_timer_stop(swg_timer_t *timer) {
+    timer->stop_counter = watch_rtc_get_counter();
+    timer->running = false;
+}
+
+uint32_t swg_timer_elapsed_ticks(const swg_timer_t *timer) {
+    if (timer->running) {
+        return watch_rtc_get_counter() - timer->start_counter;
+    }
+    return timer->stop_counter - timer->start_counter;
+}
+
+uint32_t swg_ticks_to_hundredths(uint32_t ticks) {
+    uint32_t freq = watch_rtc_get_frequency();
+    if (freq == 0) {
+        freq = 128;
+    }
+    return ticks * 100 / freq;
+}
+
+uint32_t swg_timer_elapsed_hundredths(const swg_timer_t *timer) {
+    return swg_ticks_to_hundredths(swg_timer_elapsed_ticks(timer));
+}
+
+uint8_t swg_last_digit(uint32_t hundredths) {
+    return (uint8_t)(hundredths % 10);
+}
+
+uint8_t swg_last_two_digits(uint32_t hundredths) {
+    return (uint8_t)(hundredths % 100);
+}
+
+void swg_format_hundredths(uint32_t hundredths, char *buf6) {
+    uint32_t total_seconds = hundredths / 100;
+    uint32_t frac = hundredths % 100;
+    uint32_t minutes = (total_seconds / 60) % 100;
+    uint32_t seconds = total_seconds % 60;
+    sprintf(buf6, "%02lu%02lu%02lu",
+            (unsigned long)minutes,
+            (unsigned long)seconds,
+            (unsigned long)frac);
+}

--- a/watch-faces/complication/stopwatch_game_timing.h
+++ b/watch-faces/complication/stopwatch_game_timing.h
@@ -1,0 +1,48 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Giannis Prekas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "watch_rtc.h"
+
+#define SWG_UI_TICK_HZ 16
+#define SWG_TARGET_10_HUNDREDTHS 1000
+
+typedef struct {
+    rtc_counter_t start_counter;
+    rtc_counter_t stop_counter;
+    bool running;
+} swg_timer_t;
+
+void swg_timer_reset(swg_timer_t *timer);
+void swg_timer_start(swg_timer_t *timer);
+void swg_timer_stop(swg_timer_t *timer);
+uint32_t swg_timer_elapsed_ticks(const swg_timer_t *timer);
+uint32_t swg_ticks_to_hundredths(uint32_t ticks);
+uint32_t swg_timer_elapsed_hundredths(const swg_timer_t *timer);
+uint8_t swg_last_digit(uint32_t hundredths);
+uint8_t swg_last_two_digits(uint32_t hundredths);
+void swg_format_hundredths(uint32_t hundredths, char *buf6);


### PR DESCRIPTION
**Summary**
Add a set of old-school Casio-style stopwatch games as optional Movement complication faces.

These are the kind of games people used to play on digital watches and calculator-watches: start/stop the chronograph, read the last digit(s), and let the rules decide the outcome. No fancy graphics — just timing, nerves, and a tiny LCD.

Includes a small shared helper for hundredths-of-a-second timing, plus six faces:

- Football — stopwatch soccer with set pieces and a penalty shootout
- Basketball — possessions, 2s/3s, fouls with free throws
- Bullseye — stop as close as possible to 10.00 seconds
- Blind 10 — estimate 10 seconds without looking
- Stopwatch Blackjack — push-your-luck to 100 using hundredths as card draws
- F1 Pit Stop — fastest start/stop reflex challenge
Faces are registered for opt-in use via movement_faces.h / watch-faces.mk (not forced into the default firmware face list).

I hope you enjoy them!!



**Test plan**

- Build with emmake make BOARD=sensorwatch_red DISPLAY=custom (or classic)
- Enable the faces in movement_config.h and smoke-test each game in the emulator
- Confirm Alarm start/stop, Light reset (where applicable), and Mode exit behave as expected