### PR TITLE
Clock face for the Casio F-94 with a gauge ring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ INCLUDES += \
   -I./lib/TOTP \
   -I./lib/chirpy_tx \
   -I./lib/base64 \
+  -I./lib/f94_ring \
   -I./watch-library/shared/watch \
   -I./watch-library/shared/driver \
   -I./watch-faces/clock \
@@ -105,6 +106,7 @@ SRCS += \
   ./lib/TOTP/TOTP.c \
   ./lib/chirpy_tx/chirpy_tx.c \
   ./lib/base64/base64.c \
+  ./lib/f94_ring/f94_ring.c \
   ./watch-library/shared/driver/thermistor_driver.c \
   ./watch-library/shared/watch/watch_common_buzzer.c \
   ./watch-library/shared/watch/watch_common_display.c \

--- a/lib/f94_ring/f94_ring.c
+++ b/lib/f94_ring/f94_ring.c
@@ -1,0 +1,91 @@
+/*
+ * MIT License
+ *
+ * Copyright © 2026 Konrad Rieck <konrad@mlsec.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "f94_ring.h"
+
+/* F94_RING_OFF is built in and always reads zero. Sources register from 1 up. */
+#define F94_RING_ENTRIES (F94_RING_MAX_SOURCES + 1)
+
+typedef struct {
+    const char *name;
+    f94_ring_source_t source;   /* NULL for the built-in "off" entry */
+    void *context;
+    f94_ring_mode_t mode;
+} f94_ring_entry_t;
+
+static f94_ring_entry_t _entries[F94_RING_ENTRIES] = {
+    [F94_RING_OFF] = { "OFF   ", NULL, NULL, F94_RING_FILL },
+};
+
+static uint8_t _count = 1;
+
+void f94_ring_register(const char *name, f94_ring_source_t source, void *context, f94_ring_mode_t mode)
+{
+    if (_count >= F94_RING_ENTRIES || source == NULL)
+        return;
+
+    _entries[_count].name = name;
+    _entries[_count].source = source;
+    _entries[_count].context = context;
+    _entries[_count].mode = mode;
+
+    _count++;
+}
+
+uint8_t f94_ring_scale(uint32_t value, uint32_t max)
+{
+    if (max == 0)
+        return 0;
+
+    /* Clamp first: value * F94_RING_SEGMENTS overflows uint32_t for large
+     * values, and nothing above twice max is representable. */
+    if (value > max * 2)
+        return F94_RING_DOUBLE_MAX;
+
+    return (uint8_t) (value * F94_RING_SEGMENTS / max);
+}
+
+uint8_t f94_ring_count(void)
+{
+    return _count;
+}
+
+const char *f94_ring_name(uint8_t id)
+{
+    return id < _count ? _entries[id].name : NULL;
+}
+
+uint8_t f94_ring_get(uint8_t id)
+{
+    if (id >= _count || _entries[id].source == NULL)
+        return 0;
+
+    uint8_t level = _entries[id].source(_entries[id].context);
+
+    /* Clamping per mode keeps the mode out of the clock face: a filling source
+     * never returns a level in the second lap's range. */
+    uint8_t max = _entries[id].mode == F94_RING_DOUBLE ? F94_RING_DOUBLE_MAX : F94_RING_FILL_MAX;
+
+    return level > max ? max : level;
+}

--- a/lib/f94_ring/f94_ring.c
+++ b/lib/f94_ring/f94_ring.c
@@ -42,15 +42,28 @@ static uint8_t _count = 1;
 
 void f94_ring_register(const char *name, f94_ring_source_t source, void *context, f94_ring_mode_t mode)
 {
-    if (_count >= F94_RING_ENTRIES || source == NULL)
+    if (source == NULL)
         return;
 
-    _entries[_count].name = name;
-    _entries[_count].source = source;
-    _entries[_count].context = context;
-    _entries[_count].mode = mode;
+    /* Faces register from setup(), which movement calls again after every
+     * wake from deep sleep. A known source is thus updated in place, so that
+     * the table does not fill up with one copy per wake. */
+    uint8_t id;
+    for (id = 1; id < _count; id++) {
+        if (_entries[id].source == source && _entries[id].context == context)
+            break;
+    }
 
-    _count++;
+    if (id >= F94_RING_ENTRIES)
+        return;
+
+    _entries[id].name = name;
+    _entries[id].source = source;
+    _entries[id].context = context;
+    _entries[id].mode = mode;
+
+    if (id == _count)
+        _count++;
 }
 
 uint8_t f94_ring_scale(uint32_t value, uint32_t max)

--- a/lib/f94_ring/f94_ring.h
+++ b/lib/f94_ring/f94_ring.h
@@ -51,6 +51,10 @@
  * while the source is displayed. Registering on a watch without
  * f94_clock_face is harmless, since nothing calls the source.
  *
+ * Registering the same source twice is harmless: the entry is updated in
+ * place and keeps its id. This matters because movement calls setup() again
+ * after every wake from deep sleep.
+ *
  * There are two modes of operation: F94_RING_FILL and F94_RING_DOUBLE. The
  * former fills the ring and stops there (5 steps), the latter fills the ring
  * and then clears it again (10 steps).

--- a/lib/f94_ring/f94_ring.h
+++ b/lib/f94_ring/f94_ring.h
@@ -1,0 +1,117 @@
+/*
+ * MIT License
+ *
+ * Copyright © 2026 Konrad Rieck <konrad@mlsec.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef F94_RING_H_
+#define F94_RING_H_
+
+/*
+ * F-94 QUANTITY RING
+ *
+ * The Casio F-94 shares the F-91W's LCD glass, so the classic segment map
+ * drives it unchanged. Only the printed labels differ: the segments the
+ * F-91W labels SIGNAL, PM, 24H, LAP and BELL form a ring at the top right
+ * of the F-94, labelled AL, PM, 24H, SPL and SIG there (clockwise). The
+ * f94_ring API lets a face use that ring as a gauge for a single quantity
+ * instead of as five separate indicators. For example, the ring can show
+ * progress towards a daily step goal, or the time left until a scheduled alarm.
+ *
+ * A source for the ring API registers once from its setup() and supplies a
+ * function reporting its current level:
+ *
+ *     static uint8_t _ring_level(void *context)
+ *     {
+ *         some_state_t *state = (some_state_t *) context;
+ *         return f94_ring_scale(state->value, state->max);
+ *     }
+ *
+ *     f94_ring_register("Label", _ring_level, state, F94_RING_DOUBLE);
+ *
+ * The clock face calls that function when it repaints, about once a second
+ * while the source is displayed. Registering on a watch without
+ * f94_clock_face is harmless, since nothing calls the source.
+ *
+ * There are two modes of operation: F94_RING_FILL and F94_RING_DOUBLE. The
+ * former fills the ring and stops there (5 steps), the latter fills the ring
+ * and then clears it again (10 steps).
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Segments in the ring */
+#define F94_RING_SEGMENTS 5
+
+/* Highest level an F94_RING_FILL source can report */
+#define F94_RING_FILL_MAX F94_RING_SEGMENTS
+
+/* Highest level an F94_RING_DOUBLE source can report */
+#define F94_RING_DOUBLE_MAX (F94_RING_SEGMENTS * 2)
+
+/* Sources that can register, not counting "off" entry */
+#define F94_RING_MAX_SOURCES 8
+
+/* Built-in first entry: "off" */
+#define F94_RING_OFF 0
+
+/** @brief Range of a source's levels. */
+typedef enum {
+    F94_RING_FILL = 0,
+    F94_RING_DOUBLE,
+} f94_ring_mode_t;
+
+/** @brief Reports a source's current level.
+  * @param context The context passed to f94_ring_register.
+  * @return A level within the range of the source's mode; higher values are
+  *         clamped.
+  */
+typedef uint8_t (*f94_ring_source_t)(void *context);
+
+/** @brief Registers a source of ring values.
+  * @param name Label (6 characters) for source shown in settings.
+  * @param source The function reporting the level.
+  * @param context Passed to that function; usually the face's own state.
+  * @param mode Range of this source's levels. @see f94_ring_mode_t.
+  */
+void f94_ring_register(const char *name, f94_ring_source_t source, void *context, f94_ring_mode_t mode);
+
+/** @brief Converts a value and its reference into a level.
+  * @param value The current value, for example steps walked today.
+  * @param max The value that fills the ring.
+  * @return A level from 0 to F94_RING_DOUBLE_MAX.
+  */
+uint8_t f94_ring_scale(uint32_t value, uint32_t max);
+
+/** @brief Number of entries in the registry, including the built-in "off". */
+uint8_t f94_ring_count(void);
+
+/** @brief The label of an entry, or NULL if the id is out of range. */
+const char *f94_ring_name(uint8_t id);
+
+/** @brief Reads an entry's level, clamped to the range of its mode.
+  * @return The level, or 0 for F94_RING_OFF and out of range ids.
+  */
+uint8_t f94_ring_get(uint8_t id);
+
+#endif                          /* F94_RING_H_ */

--- a/movement_faces.h
+++ b/movement_faces.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "clock_face.h"
+#include "f94_clock_face.h"
 #include "beats_face.h"
 #include "world_clock_face.h"
 #include "alarm_face.h"

--- a/watch-faces.mk
+++ b/watch-faces.mk
@@ -1,5 +1,6 @@
 SRCS += \
   ./watch-faces/clock/clock_face.c \
+  ./watch-faces/clock/f94_clock_face.c \
   ./watch-faces/clock/beats_face.c \
   ./watch-faces/clock/world_clock_face.c \
   ./watch-faces/clock/mars_time_face.c \

--- a/watch-faces/clock/f94_clock_face.c
+++ b/watch-faces/clock/f94_clock_face.c
@@ -1,0 +1,466 @@
+/*
+ * MIT License
+ *
+ * Copyright © 2026 Konrad Rieck <konrad@mlsec.org>
+ * Copyright © 2021-2023 Joey Castillo <joeycastillo@utexas.edu> <jose.castillo@gmail.com>
+ * Copyright © 2022 David Keck <davidskeck@users.noreply.github.com>
+ * Copyright © 2022 TheOnePerson <a.nebinger@web.de>
+ * Copyright © 2023 Jeremy O'Brien <neutral@fastmail.com>
+ * Copyright © 2023 Mikhail Svarichevsky <3@14.by>
+ * Copyright © 2023 Wesley Aptekar-Cassels <me@wesleyac.com>
+ * Copyright © 2024 Matheus Afonso Martins Moreira <matheus.a.m.moreira@gmail.com>
+ *
+ * The clock display is derived from clock_face.c.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "f94_clock_face.h"
+#include "f94_ring.h"
+#include "watch_utility.h"
+#include "watch_common_display.h"
+
+/* 2.4 volts seems to offer adequate warning of a low battery condition?
+ * refined based on user reports and personal observations; may need further
+ * adjustment. */
+#ifndef LOW_BATTERY_VOLTAGE
+#define LOW_BATTERY_VOLTAGE 2400
+#endif
+
+/* Ring segments of the F-94, in the order they light: clockwise from AL. */
+static const watch_indicator_t _ring_segments[F94_RING_SEGMENTS] = {
+    WATCH_INDICATOR_SIGNAL,     /* AL  */
+    WATCH_INDICATOR_PM,         /* PM  */
+    WATCH_INDICATOR_24H,        /* 24H */
+    WATCH_INDICATOR_LAP,        /* SPL */
+    WATCH_INDICATOR_BELL,       /* SIG */
+};
+
+/* Segment carrying the low battery warning: LAP on the F-91W, SPL here. */
+#define F94_RING_BATTERY WATCH_INDICATOR_LAP
+
+static void _beep(void)
+{
+    if (!movement_button_should_sound())
+        return;
+    watch_buzzer_play_note(BUZZER_NOTE_C7, 50);
+}
+
+static void _indicate(watch_indicator_t indicator, bool on)
+{
+    if (on) {
+        watch_set_indicator(indicator);
+    } else {
+        watch_clear_indicator(indicator);
+    }
+}
+
+/* Needs the hour before it is folded to 12h. */
+static void _indicate_pm(watch_date_time_t date_time)
+{
+    _indicate(WATCH_INDICATOR_PM, date_time.unit.hour >= 12);
+}
+
+/* Restores the five segments to their default meaning. PM is only cleared
+ * here; the next clock redraw sets it. */
+static void _display_default(f94_state_t *state)
+{
+    _indicate(WATCH_INDICATOR_SIGNAL, movement_alarm_enabled());
+    _indicate(WATCH_INDICATOR_BELL, state->time_signal);
+    _indicate(WATCH_INDICATOR_24H, movement_clock_mode_24h() != MOVEMENT_CLOCK_MODE_12H);
+    _indicate(F94_RING_BATTERY, state->battery_low);
+    _indicate(WATCH_INDICATOR_PM, false);
+}
+
+/* Fills the ring up to F94_RING_SEGMENTS, then clears it again in the same
+ * order. */
+static bool _ring_lit(uint8_t level, uint8_t index)
+{
+    if (level <= F94_RING_SEGMENTS)
+        return index < level;
+
+    return index >= level - F94_RING_SEGMENTS;
+}
+
+/* Paints the ring only if the level changed. */
+static void _display_ring(f94_state_t *state)
+{
+    if (state->ring_source == F94_RING_OFF)
+        return;
+
+    /* The low battery warning preempts the source. */
+    uint8_t level = state->battery_low ? F94_LEVEL_BATTERY : f94_ring_get(state->ring_source);
+
+    if (level == state->ring_shown)
+        return;
+
+    state->ring_shown = level;
+
+    for (uint8_t i = 0; i < F94_RING_SEGMENTS; i++) {
+        bool lit = level == F94_LEVEL_BATTERY ? _ring_segments[i] == F94_RING_BATTERY : _ring_lit(level, i);
+
+        _indicate(_ring_segments[i], lit);
+    }
+}
+
+/* Source for 60SEC: One segment every ten seconds. (F94_RING_FILL) */
+static uint8_t _level_minute(void *context)
+{
+    (void) context;
+
+    return movement_get_local_date_time().unit.second / 10;
+}
+
+/* Source for 5SEC: One segment every second (F94_RING_DOUBLE) */
+static uint8_t _level_seconds(void *context)
+{
+    (void) context;
+
+    return movement_get_local_date_time().unit.second % F94_RING_DOUBLE_MAX;
+}
+
+/* Full repaint of all five segments, source or default. */
+static void _display_indicators(f94_state_t *state)
+{
+    /* Whatever is on screen no longer matches ring_shown. */
+    state->ring_shown = F94_LEVEL_UNKNOWN;
+
+    if (state->ring_source == F94_RING_OFF)
+        _display_default(state);
+    else
+        _display_ring(state);
+}
+
+/* Clear all five segments */
+static void _clear_indicators(f94_state_t *state)
+{
+    for (uint8_t i = 0; i < F94_RING_SEGMENTS; i++)
+        _indicate(_ring_segments[i], false);
+
+    state->ring_shown = F94_LEVEL_UNKNOWN;
+}
+
+static watch_date_time_t _to_12h(watch_date_time_t date_time)
+{
+    date_time.unit.hour %= 12;
+
+    if (date_time.unit.hour == 0) {
+        date_time.unit.hour = 12;
+    }
+
+    return date_time;
+}
+
+static void _check_battery(f94_state_t *state, watch_date_time_t date_time)
+{
+    /* check the battery voltage once a day */
+    if (date_time.unit.day == state->last_battery_check) {
+        return;
+    }
+
+    state->last_battery_check = date_time.unit.day;
+
+    uint16_t voltage = watch_get_vcc_voltage();
+
+    state->battery_low = voltage < LOW_BATTERY_VOLTAGE;
+
+    /* Set the low battery indicator if battery power is low. With a source
+     * selected, the next _display_ring picks this up instead. */
+    if (state->ring_source == F94_RING_OFF)
+        _indicate(F94_RING_BATTERY, state->battery_low);
+}
+
+static void _toggle_time_signal(f94_state_t *state)
+{
+    state->time_signal = !state->time_signal;
+
+    /* No BELL indicator with a source selected; the beep is the feedback. */
+    if (state->ring_source == F94_RING_OFF)
+        _indicate(WATCH_INDICATOR_BELL, state->time_signal);
+}
+
+static void _display_all(watch_date_time_t date_time)
+{
+    char buf[8 + 1];
+
+    snprintf(buf,
+             sizeof(buf),
+             movement_clock_mode_24h() == MOVEMENT_CLOCK_MODE_024H ? "%02d%02d%02d%02d" : "%2d%2d%02d%02d",
+             date_time.unit.day, date_time.unit.hour, date_time.unit.minute, date_time.unit.second);
+
+    watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, watch_utility_get_long_weekday(date_time),
+                                     watch_utility_get_weekday(date_time));
+    watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+    watch_display_text(WATCH_POSITION_BOTTOM, buf + 2);
+}
+
+static bool _display_some(watch_date_time_t current, watch_date_time_t previous)
+{
+    if ((current.reg >> 6) == (previous.reg >> 6)) {
+        /* everything before seconds is the same, don't waste cycles setting
+         * those segments. */
+
+        watch_display_character_lp_seconds('0' + current.unit.second / 10, 8);
+        watch_display_character_lp_seconds('0' + current.unit.second % 10, 9);
+
+        return true;
+
+    } else if ((current.reg >> 12) == (previous.reg >> 12)) {
+        /* everything before minutes is the same. */
+
+        char buf[4 + 1];
+
+        snprintf(buf, sizeof(buf), "%02d%02d", current.unit.minute, current.unit.second);
+
+        watch_display_text(WATCH_POSITION_MINUTES, buf);
+        watch_display_text(WATCH_POSITION_SECONDS, buf + 2);
+
+        return true;
+
+    } else {
+        /* other stuff changed; let's do it all. */
+        return false;
+    }
+}
+
+static void _display_clock(f94_state_t *state, watch_date_time_t current)
+{
+    if (!_display_some(current, state->previous)) {
+        if (movement_clock_mode_24h() == MOVEMENT_CLOCK_MODE_12H) {
+            /* PM belongs to the ring with a source selected, so 12h mode
+             * can't show which half of the day it is. */
+            if (state->ring_source == F94_RING_OFF)
+                _indicate_pm(current);
+            current = _to_12h(current);
+        }
+        _display_all(current);
+    }
+}
+
+static void _display_low_energy(f94_state_t *state, watch_date_time_t date_time)
+{
+    if (movement_clock_mode_24h() == MOVEMENT_CLOCK_MODE_12H) {
+        if (state->ring_source == F94_RING_OFF)
+            _indicate_pm(date_time);
+        date_time = _to_12h(date_time);
+    }
+    char buf[8 + 1];
+
+    snprintf(buf,
+             sizeof(buf),
+             movement_clock_mode_24h() == MOVEMENT_CLOCK_MODE_024H ? "%02d%02d%02d  " : "%2d%2d%02d  ",
+             date_time.unit.day, date_time.unit.hour, date_time.unit.minute);
+
+    watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, watch_utility_get_long_weekday(date_time),
+                                     watch_utility_get_weekday(date_time));
+    watch_display_text(WATCH_POSITION_TOP_RIGHT, buf);
+    watch_display_text(WATCH_POSITION_BOTTOM, buf + 2);
+}
+
+static void _start_sleep_animation(void)
+{
+    if (!watch_sleep_animation_is_running()) {
+        watch_start_sleep_animation(500);
+        watch_start_indicator_blink_if_possible(WATCH_INDICATOR_COLON, 500);
+    }
+}
+
+static void _stop_sleep_animation(void)
+{
+    if (watch_sleep_animation_is_running()) {
+        watch_stop_sleep_animation();
+        watch_stop_blink();
+    }
+}
+
+static void _settings_display(f94_state_t *state, uint8_t subsecond)
+{
+    const char *value = f94_ring_name(state->ring_source);
+
+    /* The page label goes in the top left; settings mode shows no colon. */
+    watch_clear_colon();
+    watch_display_text_with_fallback(WATCH_POSITION_TOP_LEFT, "SO", "SO");
+
+    /* Blink the value being edited. */
+    if (subsecond % 2 == 0)
+        value = "      ";
+    watch_display_text_with_fallback(WATCH_POSITION_BOTTOM, value, value);
+}
+
+/* Back to the clock, restoring what settings mode took over. */
+static void _leave_settings(f94_state_t *state)
+{
+    state->page = PAGE_F94_CLOCK;
+    /* this ensures that none of the timestamp fields will match, so we can
+     * re-render them all. */
+    state->previous.reg = 0xFFFFFFFF;
+    watch_set_colon();          /* restore the colon hidden by settings */
+    _display_indicators(state);
+    movement_request_tick_frequency(1);
+}
+
+static bool _settings_loop(movement_event_t event, f94_state_t *state)
+{
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+        case EVENT_TICK:
+            _settings_display(state, event.subsecond);
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            /* The segments stay dark until we leave; the name is the feedback. */
+            state->ring_source = (state->ring_source + 1) % f94_ring_count();
+            _settings_display(state, event.subsecond);
+            break;
+        case EVENT_MODE_BUTTON_UP:
+            _leave_settings(state);
+            _beep();
+            break;
+        case EVENT_TIMEOUT:
+            _leave_settings(state);
+            break;
+        default:
+            return movement_default_loop_handler(event);
+    }
+
+    return true;
+}
+
+void f94_clock_face_setup(uint8_t watch_face_index, void **context_ptr)
+{
+    (void) watch_face_index;
+
+    if (*context_ptr != NULL)
+        return;
+
+    f94_state_t *state = malloc(sizeof(f94_state_t));
+
+    memset(state, 0, sizeof(*state));
+    state->ring_source = F94_RING_OFF;
+    state->ring_shown = F94_LEVEL_UNKNOWN;
+
+    /* Registered first, so their place in the list is independent of the lineup. */
+    f94_ring_register("60SEC ", _level_minute, NULL, F94_RING_FILL);
+    f94_ring_register(" 5SEC ", _level_seconds, NULL, F94_RING_DOUBLE);
+
+    *context_ptr = state;
+}
+
+void f94_clock_face_activate(void *context)
+{
+    f94_state_t *state = (f94_state_t *) context;
+
+    _stop_sleep_animation();
+
+    watch_set_colon();
+
+    /* Settings runs at 4 Hz to blink the value and owns the segments; the
+     * previous face may have left them in any state. */
+    switch (state->page) {
+        case PAGE_F94_SETTINGS:
+            movement_request_tick_frequency(4);
+            _clear_indicators(state);
+            break;
+        default:
+        case PAGE_F94_CLOCK:
+            movement_request_tick_frequency(1);
+            _display_indicators(state);
+            break;
+    }
+
+    /* this ensures that none of the timestamp fields will match, so we can
+     * re-render them all. */
+    state->previous.reg = 0xFFFFFFFF;
+}
+
+static bool _clock_loop(movement_event_t event, f94_state_t *state)
+{
+    watch_date_time_t current;
+
+    switch (event.event_type) {
+        case EVENT_LOW_ENERGY_UPDATE:
+            _start_sleep_animation();
+            _display_low_energy(state, movement_get_local_date_time());
+            /* The ring freezes here; repainting would cost power for a
+             * reading that is stale until the next tick. */
+            break;
+        case EVENT_TICK:
+        case EVENT_ACTIVATE:
+            current = movement_get_local_date_time();
+
+            _display_clock(state, current);
+
+            _check_battery(state, current);
+            _display_ring(state);
+
+            state->previous = current;
+
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            _toggle_time_signal(state);
+            _beep();
+            break;
+        case EVENT_LIGHT_LONG_PRESS:
+            state->page = PAGE_F94_SETTINGS;
+            movement_request_tick_frequency(4);
+            _clear_indicators(state);
+            _settings_display(state, event.subsecond);
+            _beep();
+            break;
+        case EVENT_BACKGROUND_TASK:
+            if (state->time_signal && movement_get_local_date_time().unit.minute == 0)
+                movement_play_signal();
+            break;
+        default:
+            return movement_default_loop_handler(event);
+    }
+
+    return true;
+}
+
+bool f94_clock_face_loop(movement_event_t event, void *context)
+{
+    f94_state_t *state = (f94_state_t *) context;
+
+    switch (state->page) {
+        case PAGE_F94_SETTINGS:
+            return _settings_loop(event, state);
+        default:
+        case PAGE_F94_CLOCK:
+            return _clock_loop(event, state);
+    }
+}
+
+void f94_clock_face_resign(void *context)
+{
+    (void) context;
+}
+
+movement_watch_face_advisory_t f94_clock_face_advise(void *context)
+{
+    movement_watch_face_advisory_t retval = { 0 };
+    f94_state_t *state = (f94_state_t *) context;
+
+    /* Only the chime needs a background task; skip the clock read when it is off. */
+    if (state->time_signal)
+        retval.wants_background_task = movement_get_local_date_time().unit.minute == 0;
+
+    return retval;
+}

--- a/watch-faces/clock/f94_clock_face.c
+++ b/watch-faces/clock/f94_clock_face.c
@@ -356,7 +356,6 @@ void f94_clock_face_setup(uint8_t watch_face_index, void **context_ptr)
     state->ring_source = F94_RING_OFF;
     state->ring_shown = F94_LEVEL_UNKNOWN;
 
-    /* Registered first, so their place in the list is independent of the lineup. */
     f94_ring_register("60SEC ", _level_minute, NULL, F94_RING_FILL);
     f94_ring_register(" 5SEC ", _level_seconds, NULL, F94_RING_DOUBLE);
 

--- a/watch-faces/clock/f94_clock_face.h
+++ b/watch-faces/clock/f94_clock_face.h
@@ -1,0 +1,99 @@
+/*
+ * MIT License
+ *
+ * Copyright © 2026 Konrad Rieck <konrad@mlsec.org>
+ * Copyright © 2021-2023 Joey Castillo <joeycastillo@utexas.edu> <jose.castillo@gmail.com>
+ * Copyright © 2022 David Keck <davidskeck@users.noreply.github.com>
+ * Copyright © 2022 TheOnePerson <a.nebinger@web.de>
+ * Copyright © 2023 Jeremy O'Brien <neutral@fastmail.com>
+ * Copyright © 2023 Mikhail Svarichevsky <3@14.by>
+ * Copyright © 2023 Wesley Aptekar-Cassels <me@wesleyac.com>
+ * Copyright © 2024 Matheus Afonso Martins Moreira <matheus.a.m.moreira@gmail.com>
+ *
+ * The clock display is derived from clock_face.c.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef F94_CLOCK_FACE_H_
+#define F94_CLOCK_FACE_H_
+
+/*
+ * F-94 CLOCK FACE
+ *
+ * The standard clock face for a Sensor Watch in a Casio F-94 case. The F-94
+ * shares the F-91W segment map. However, its five indicators form a ring at
+ * the top right of the display. This watch face lets you use this ring as a
+ * gauge for a single quantity instead of as separate indicators. For
+ * example, it can be used to display the progress towards a daily step
+ * goal, or the time remaining until a scheduled alarm.
+ *
+ * A watch face can register a source for the ring; see f94_ring.h for
+ * details. Two sources are built-in: 60SEC fills the ring over a minute,
+ * one segment every ten seconds (mode F94_RING_FILL). 5SEC fills the ring
+ * over 5 seconds and clears it again over the next 5 seconds (mode
+ * F94_RING_DOUBLE).
+ *
+ * The default source is OFF. The segments then carry their original meaning
+ * (alarm, hourly chime, PM, 24H and low battery) and the face behaves as the
+ * standard clock face. Any other source takes all five segments, so none of
+ * those indications are available while it is selected. The exception is the
+ * low battery warning, which preempts the ring on the SPL segment.
+ *
+ * Long-press LIGHT for settings, where ALARM selects the source and MODE
+ * leaves.
+ */
+
+#include "movement.h"
+
+typedef enum {
+    PAGE_F94_CLOCK = 0,
+    PAGE_F94_SETTINGS,
+} f94_page_t;
+
+#define F94_LEVEL_UNKNOWN 0xFF
+#define F94_LEVEL_BATTERY 0xFE
+
+typedef struct {
+    watch_date_time_t previous; /* Time shown on the last tick */
+    uint8_t last_battery_check; /* Day of the last battery check */
+    bool time_signal;           /* Hourly time signal enabled */
+    bool battery_low;           /* Battery voltage is low */
+    f94_page_t page;            /* Current page */
+
+    /* Ring */
+    uint8_t ring_source;        /* Registry id of the source on show */
+    uint8_t ring_shown;         /* Level last painted, or F94_LEVEL_UNKNOWN */
+} f94_state_t;
+
+void f94_clock_face_setup(uint8_t watch_face_index, void **context_ptr);
+void f94_clock_face_activate(void *context);
+bool f94_clock_face_loop(movement_event_t event, void *context);
+void f94_clock_face_resign(void *context);
+movement_watch_face_advisory_t f94_clock_face_advise(void *context);
+
+#define f94_clock_face ((const watch_face_t) { \
+    f94_clock_face_setup, \
+    f94_clock_face_activate, \
+    f94_clock_face_loop, \
+    f94_clock_face_resign, \
+    f94_clock_face_advise, \
+})
+
+#endif                          /* F94_CLOCK_FACE_H_ */


### PR DESCRIPTION
The [Casio F-94](https://www.casio.com/intl/watches/casio/product.F-94WA-9/) is pin-compatible with the Sensor Watch, and its LCD has the same dimensions as the F-91W's. The classic segment map therefore drives it unchanged, and the digits need no special handling. What differs is that the five indicators (signal, bell, and so on) sit in a ring at the top right, which makes them useful as a gauge.

`f94_clock_face` is the standard clock face plus the option of displaying a gauge, which fills the ring clockwise. Any watch face can register a source for the gauge with `f94_ring`, and the user can select which source is shown at runtime. The source list always starts with `OFF`, which shows the stock indicators; a long press on the light button lets you change this and pick a source for the gauge. Two sources are built in: `60SEC` fills the ring over a minute, and `5SEC` fills and empties it every ten seconds.

The gauge can be used in two modes: `F94_RING_FILL`, which simply fills the five segments of the ring clockwise, and `F94_RING_DOUBLE`, which first fills and then clears them, thereby providing ten steps. Further details are available in `f94_ring.h`.



https://github.com/user-attachments/assets/74787f4f-83cb-4417-85c0-848beada0419


