### PR TITLE
set_time_face: clamp the day when changing year or month

### DIFF
--- a/watch-faces/settings/set_time_face.c
+++ b/watch-faces/settings/set_time_face.c
@@ -47,9 +47,21 @@ static void _handle_alarm_button(watch_date_time_t date_time, uint8_t current_pa
             return;
         case 0: // year
             date_time.unit.year = (date_time.unit.year + 1) % 60;
+            // e.g. Feb 29 in a leap year, advanced into a non-leap year: clamp the day down
+            // to the new year's actual last day of that month, rather than let it silently
+            // overflow into the next month (watch_utility_date_time_to_unix_time has no
+            // concept of "invalid day", it just adds (day-1)*86400 on top of the month).
+            if (date_time.unit.day > watch_utility_days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR)) {
+                date_time.unit.day = watch_utility_days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR);
+            }
             break;
         case 1: // month
             date_time.unit.month = (date_time.unit.month % 12) + 1;
+            // Same clamp as above -- e.g. day 30 or 31, advanced into February, would
+            // otherwise silently overflow into the following month.
+            if (date_time.unit.day > watch_utility_days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR)) {
+                date_time.unit.day = watch_utility_days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR);
+            }
             break;
         case 2: // day
             date_time.unit.day = (date_time.unit.day % watch_utility_days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR)) + 1;


### PR DESCRIPTION
Advancing the year or the month can leave the day out of range for the
new date -- Feb 29 carried into a non-leap year, or day 30/31 carried
into February. `watch_utility_date_time_to_unix_time` has no concept of
an invalid day, it just adds (day - 1) * 86400 on top of the month, so
the date silently rolls over into the next month.

This clamps the day to the last valid day of the resulting month.